### PR TITLE
change the behavior of whereIn when passing empty array to it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $result = $qb->table('users')
    ->select('id', 'username', 'phone_number', 'gender')
    ->where('role_id', '=', 1)
    ->join('images', 'images.user_id', '=', 'users.id')
-   ->get()
+   ->get();
 ```
 
 ## Select with pagination
@@ -35,14 +35,14 @@ You can either use the `paginate` method or the `simplePaginate` method.
 $paginator = $qb->table('users')
    ->select('id', 'username', 'phone_number', 'gender')
    ->where('role_id', '=', 1)
-   ->paginate($page, $limit)
+   ->paginate($page, $limit);
 ```
 `simplePaginate` will return a `Paginator` instance which contains the current page, the number of items per page, and the number of next and previous pages. <br>
 ```php
 $paginator = $qb->table('users')
    ->select('id', 'username', 'phone_number', 'gender')
    ->where('role_id', '=', 1)
-   ->simplePaginate($page, $limit)
+   ->simplePaginate($page, $limit);
 ```
 
 ## Nested Where
@@ -54,16 +54,18 @@ $result = $qb->table('users')
        $builder->where('role_id', '=', 1)
            ->orWhere('role_id', '=', 2); 
    })
-   ->get()
+   ->get();
 ```
 ## Nested Join
 You can add nested conditions to the Join clause by passing a closure to the `join` method. <br>
 ```php
-      ->join('images', function (JoinClauseBuilder $builder) {
-                $builder->on('images.user_id', '=', 'users.id');
-                   // you can use all where variants here
-                $builder->where('images.user_id', '=', 1);
-            })
+$result = $qb->table('users')
+    ->join('images', function (JoinClauseBuilder $builder) {
+        $builder->on('images.user_id', '=', 'users.id');
+        // you can use all where variants here
+        $builder->where('images.user_id', '=', 1);
+    })
+    ->get();
 ```
 ## TODOs
 - [x] ~~Support Update, Delete, Insert~~

--- a/composer.lock
+++ b/composer.lock
@@ -235,16 +235,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.7",
+            "version": "10.1.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "355324ca4980b8916c18b9db29f3ef484078f26e"
+                "reference": "a56a9ab2f680246adcf3db43f38ddf1765774735"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/355324ca4980b8916c18b9db29f3ef484078f26e",
-                "reference": "355324ca4980b8916c18b9db29f3ef484078f26e",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/a56a9ab2f680246adcf3db43f38ddf1765774735",
+                "reference": "a56a9ab2f680246adcf3db43f38ddf1765774735",
                 "shasum": ""
             },
             "require": {
@@ -301,7 +301,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.7"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.9"
             },
             "funding": [
                 {
@@ -309,7 +309,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-04T15:34:17+00:00"
+            "time": "2023-11-23T12:23:20+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1572,16 +1572,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.1",
+            "version": "1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
-                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
+                "reference": "b2ad5003ca10d4ee50a12da31de12a5774ba6b96",
                 "shasum": ""
             },
             "require": {
@@ -1610,7 +1610,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.2"
             },
             "funding": [
                 {
@@ -1618,7 +1618,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-07-28T10:34:58+00:00"
+            "time": "2023-11-20T00:12:19+00:00"
         }
     ],
     "aliases": [],

--- a/src/Builders/WhereQueryBuilder.php
+++ b/src/Builders/WhereQueryBuilder.php
@@ -110,6 +110,7 @@ class WhereQueryBuilder
     ): self
     {
         if (empty($values)) {
+            $this->addEmptyWhereIn($column, $values, $and);
             return $this;
         }
         $placeholders = [];
@@ -125,6 +126,21 @@ class WhereQueryBuilder
         );
         $this->whereClause->addCondition($condition);
         return $this;
+    }
+
+    private function addEmptyWhereIn(
+        string $column,
+        array  $values,
+        bool   $and = true
+    ): void
+    {
+        $condition = new Condition(
+            1,
+            '=',
+            0,
+            $and ? Conjunction::AND() : Conjunction::OR()
+        );
+        $this->whereClause->addCondition($condition);
     }
 
     public function whereNotIn(

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -398,4 +398,13 @@ class QueryBuilderTest extends TestCase
         $name = $builder->table('users')->where('id', '=', 2)->first('name');
         $this->assertNull($name);
     }
+
+    public function testEmptyWhereIn() {
+        $builder = new QueryBuilder($this->pdo);
+        $query = $builder
+            ->table('users')
+            ->whereIn('id', [])
+            ->toSql();
+        $this->assertEquals('SELECT * FROM users WHERE 1 = 0;', $query);
+    }
 }


### PR DESCRIPTION
Previously, it would just remove the `where in` condition, but now it will substitute it with a false condition. This ensures that when you have multiple conditions in where you will still get the expected result when the `whereIn` is provided an empty array.