### PR TITLE
Dev > Main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # QueryBuilder
 Fast, lightweight, and simple SQL query builder that does not depend on any third-party library besides PDO to execute the queries in a safe way. The syntax is inspired by Laravel Query Builder.
 
-# Important
-Do not use it in production as it is still in beta and many public APIs might change.
 ## Features
 
 - Internal bindings manager, so you do not have to worry about binding your values.

--- a/src/Builders/WhereQueryBuilder.php
+++ b/src/Builders/WhereQueryBuilder.php
@@ -110,7 +110,7 @@ class WhereQueryBuilder
     ): self
     {
         if (empty($values)) {
-            $this->addEmptyWhereIn($column, $values, $and);
+            $this->addEmptyWhereIn($and);
             return $this;
         }
         $placeholders = [];
@@ -129,8 +129,6 @@ class WhereQueryBuilder
     }
 
     private function addEmptyWhereIn(
-        string $column,
-        array  $values,
         bool   $and = true
     ): void
     {

--- a/src/Builders/WhereQueryBuilder.php
+++ b/src/Builders/WhereQueryBuilder.php
@@ -6,6 +6,7 @@ use Abdulelahragih\QueryBuilder\Grammar\Clauses\Condition;
 use Abdulelahragih\QueryBuilder\Grammar\Clauses\ConditionsGroup;
 use Abdulelahragih\QueryBuilder\Grammar\Clauses\Conjunction;
 use Abdulelahragih\QueryBuilder\Grammar\Clauses\WhereClause;
+use Abdulelahragih\QueryBuilder\Grammar\Expression;
 use Abdulelahragih\QueryBuilder\Helpers\BindingsManager;
 use Closure;
 use InvalidArgumentException;
@@ -53,7 +54,7 @@ class WhereQueryBuilder
             throw new InvalidArgumentException('Invalid operator ' . $operator);
         }
         $placeholder = $this->bindingsManager->add($value);
-        $condition = new Condition($column, $operator, $placeholder, $and ? Conjunction::AND() : Conjunction::OR());
+        $condition = new Condition($column, $operator, Expression::make($placeholder), $and ? Conjunction::AND() : Conjunction::OR());
 
         $this->whereClause->addCondition($condition);
         return $this;
@@ -70,9 +71,9 @@ class WhereQueryBuilder
     }
 
     public function orWhere(
-        mixed                      $column,
-        ?string                    $operator = null,
-        string|int|float|bool|null $value = null
+        mixed                                 $column,
+        ?string                               $operator = null,
+        Expression|string|int|float|bool|null $value = null
     ): self
     {
         $this->where($column, $operator, $value, false);
@@ -80,33 +81,33 @@ class WhereQueryBuilder
     }
 
     public function whereLike(
-        string                $column,
+        Expression|string     $column,
         string|int|float|bool $value,
         bool                  $and = true
     ): self
     {
         $placeholder = $this->bindingsManager->add($value);
-        $condition = new Condition($column, 'LIKE', $placeholder, $and ? Conjunction::AND() : Conjunction::OR());
+        $condition = new Condition($column, 'LIKE', Expression::make($placeholder), $and ? Conjunction::AND() : Conjunction::OR());
         $this->whereClause->addCondition($condition);
         return $this;
     }
 
     public function whereNotLike(
-        string                $column,
+        Expression|string     $column,
         string|int|float|bool $value,
         bool                  $and = true
     ): self
     {
         $placeholder = $this->bindingsManager->add($value);
-        $condition = new Condition($column, 'NOT LIKE', $placeholder, $and ? Conjunction::AND() : Conjunction::OR());
+        $condition = new Condition($column, 'NOT LIKE', Expression::make($placeholder), $and ? Conjunction::AND() : Conjunction::OR());
         $this->whereClause->addCondition($condition);
         return $this;
     }
 
     public function whereIn(
-        string $column,
-        array  $values,
-        bool   $and = true
+        Expression|string $column,
+        array             $values,
+        bool              $and = true
     ): self
     {
         if (empty($values)) {
@@ -121,7 +122,7 @@ class WhereQueryBuilder
         $condition = new Condition(
             $column,
             'IN',
-            '(' . implode(', ', $placeholders) . ')',
+            Expression::make('(' . implode(', ', $placeholders) . ')'),
             $and ? Conjunction::AND() : Conjunction::OR()
         );
         $this->whereClause->addCondition($condition);
@@ -129,22 +130,22 @@ class WhereQueryBuilder
     }
 
     private function addEmptyWhereIn(
-        bool   $and = true
+        bool $and = true
     ): void
     {
         $condition = new Condition(
-            1,
+            Expression::make(1),
             '=',
-            0,
+            Expression::make(0),
             $and ? Conjunction::AND() : Conjunction::OR()
         );
         $this->whereClause->addCondition($condition);
     }
 
     public function whereNotIn(
-        string $column,
-        array  $values,
-        bool   $and = true
+        Expression|string $column,
+        array             $values,
+        bool              $and = true
     ): self
     {
         if (empty($values)) {
@@ -158,7 +159,7 @@ class WhereQueryBuilder
         $condition = new Condition(
             $column,
             'NOT IN',
-            '(' . implode(', ', $placeholders) . ')',
+            Expression::make('(' . implode(', ', $placeholders) . ')'),
             $and ? Conjunction::AND() : Conjunction::OR()
         );
         $this->whereClause->addCondition($condition);
@@ -166,27 +167,27 @@ class WhereQueryBuilder
     }
 
     public function whereNull(
-        string $column,
-        bool   $and = true
+        Expression|string $column,
+        bool              $and = true
     ): self
     {
-        $condition = new Condition($column, 'IS', 'NULL', $and ? Conjunction::AND() : Conjunction::OR());
+        $condition = new Condition($column, 'IS', Expression::make('NULL'), $and ? Conjunction::AND() : Conjunction::OR());
         $this->whereClause->addCondition($condition);
         return $this;
     }
 
     public function whereNotNull(
-        string $column,
-        bool   $and = true
+        Expression|string $column,
+        bool              $and = true
     ): self
     {
-        $condition = new Condition($column, 'IS', 'NOT NULL', $and ? Conjunction::AND() : Conjunction::OR());
+        $condition = new Condition($column, 'IS', Expression::make('NOT NULL'), $and ? Conjunction::AND() : Conjunction::OR());
         $this->whereClause->addCondition($condition);
         return $this;
     }
 
     public function whereBetween(
-        string                $column,
+        Expression|string     $column,
         string|int|float|bool $value1,
         string|int|float|bool $value2,
         bool                  $and = true
@@ -197,7 +198,7 @@ class WhereQueryBuilder
         $condition = new Condition(
             $column,
             'BETWEEN',
-            "$placeholder1 AND $placeholder2",
+            Expression::make("$placeholder1 AND $placeholder2"),
             $and ? Conjunction::AND() : Conjunction::OR()
         );
         $this->whereClause->addCondition($condition);
@@ -205,7 +206,7 @@ class WhereQueryBuilder
     }
 
     public function whereNotBetween(
-        string                $column,
+        Expression|string     $column,
         string|int|float|bool $value1,
         string|int|float|bool $value2,
         bool                  $and = true
@@ -216,10 +217,15 @@ class WhereQueryBuilder
         $condition = new Condition(
             $column,
             'NOT BETWEEN',
-            "$placeholder1 AND $placeholder2",
+            Expression::make("$placeholder1 AND $placeholder2"),
             $and ? Conjunction::AND() : Conjunction::OR()
         );
         $this->whereClause->addCondition($condition);
         return $this;
+    }
+
+    public function raw(string $value): Expression
+    {
+        return Expression::make($value);
     }
 }

--- a/src/DB.php
+++ b/src/DB.php
@@ -3,6 +3,7 @@
 namespace Abdulelahragih\QueryBuilder;
 
 use Abdulelahragih\QueryBuilder\Data\Collection;
+use Abdulelahragih\QueryBuilder\Grammar\Expression;
 use Closure;
 use Exception;
 use PDO;
@@ -84,5 +85,10 @@ class DB
             $items = array_map($this->objConverter, $items);
         }
         return Collection::make($items);
+    }
+
+    public function raw(string $value): Expression
+    {
+        return Expression::make($value);
     }
 }

--- a/src/DBSingleton.php
+++ b/src/DBSingleton.php
@@ -2,6 +2,7 @@
 
 namespace Abdulelahragih\QueryBuilder;
 
+use Abdulelahragih\QueryBuilder\Grammar\Expression;
 use Closure;
 use Exception;
 use PDO;
@@ -75,6 +76,11 @@ class DBSingleton
     public static function lastInsertId(): string
     {
         return self::$pdo->lastInsertId();
+    }
+
+    public static function raw(string $value): Expression
+    {
+        return Expression::make($value);
     }
 
 }

--- a/src/Grammar/Clauses/Condition.php
+++ b/src/Grammar/Clauses/Condition.php
@@ -3,26 +3,30 @@ declare(strict_types=1);
 
 namespace Abdulelahragih\QueryBuilder\Grammar\Clauses;
 
+use Abdulelahragih\QueryBuilder\Grammar\Expression;
+use Abdulelahragih\QueryBuilder\Helpers\SqlUtils;
+
 class Condition implements Clause
 {
-    public readonly string $left;
+    public readonly Expression|string $left;
     public readonly string $operator;
-    public readonly string $right;
+    public readonly Expression|string $right;
 
     public Conjunction $conjunction;
 
     /**
-     * @param string $left
+     * @param Expression|string $left
      * @param string $operator
-     * @param string $right
+     * @param Expression|string $right
      * @param Conjunction|null $conjunction
      */
     public function __construct(
-        string       $left,
-        string       $operator,
-        string       $right,
-        ?Conjunction $conjunction = null,
-    ) {
+        Expression|string $left,
+        string            $operator,
+        Expression|string $right,
+        ?Conjunction      $conjunction = null,
+    )
+    {
         $this->left = $left;
         $this->operator = $operator;
         $this->right = $right;
@@ -31,6 +35,6 @@ class Condition implements Clause
 
     public function build(): string
     {
-        return $this->left . ' ' . $this->operator . ' ' . $this->right;
+        return SqlUtils::quoteIdentifier($this->left) . ' ' . $this->operator . ' ' . SqlUtils::quoteIdentifier($this->right);
     }
 }

--- a/src/Grammar/Clauses/FromClause.php
+++ b/src/Grammar/Clauses/FromClause.php
@@ -2,15 +2,18 @@
 
 namespace Abdulelahragih\QueryBuilder\Grammar\Clauses;
 
+use Abdulelahragih\QueryBuilder\Grammar\Expression;
+use Abdulelahragih\QueryBuilder\Helpers\SqlUtils;
+
 class FromClause implements Clause
 {
 
-    public function __construct(public readonly string $table)
+    public function __construct(public readonly Expression|string $table)
     {
     }
 
     public function build(): string
     {
-        return 'FROM ' . $this->table;
+        return 'FROM ' . SqlUtils::quoteIdentifier($this->table);
     }
 }

--- a/src/Grammar/Clauses/JoinClause.php
+++ b/src/Grammar/Clauses/JoinClause.php
@@ -3,20 +3,22 @@ declare(strict_types=1);
 
 namespace Abdulelahragih\QueryBuilder\Grammar\Clauses;
 
+use Abdulelahragih\QueryBuilder\Grammar\Expression;
+use Abdulelahragih\QueryBuilder\Helpers\SqlUtils;
 use Abdulelahragih\QueryBuilder\Types\JoinType;
 
 class JoinClause implements Clause
 {
-    private string $table;
+    private Expression|string $table;
     private ConditionsClause $conditionClauses;
     private JoinType $joinType;
 
     /**
-     * @param string $table
+     * @param Expression|string $table
      * @param ConditionsClause $conditionClauses
      * @param JoinType $joinType
      */
-    public function __construct(string $table, ConditionsClause $conditionClauses, JoinType $joinType = JoinType::Inner)
+    public function __construct(Expression|string $table, ConditionsClause $conditionClauses, JoinType $joinType = JoinType::Inner)
     {
         $this->table = $table;
         $this->conditionClauses = $conditionClauses;
@@ -29,6 +31,6 @@ class JoinClause implements Clause
      */
     public function build(): string
     {
-        return $this->joinType->value . ' JOIN ' . $this->table . ' ON ' . $this->conditionClauses->build();
+        return $this->joinType->value . ' JOIN ' . SqlUtils::quoteIdentifier($this->table) . ' ON ' . $this->conditionClauses->build();
     }
 }

--- a/src/Grammar/Clauses/OrderByClause.php
+++ b/src/Grammar/Clauses/OrderByClause.php
@@ -2,31 +2,39 @@
 
 namespace Abdulelahragih\QueryBuilder\Grammar\Clauses;
 
+use Abdulelahragih\QueryBuilder\Grammar\Expression;
+use Abdulelahragih\QueryBuilder\Helpers\SqlUtils;
 use Abdulelahragih\QueryBuilder\Types\OrderType;
 
 class OrderByClause implements Clause
 {
 
-    private array $columnsToOrderType;
+    private array $columnsAndOrderTypes;
 
     public function __construct()
     {
-        $this->columnsToOrderType = [];
+        $this->columnsAndOrderTypes = [];
     }
 
-    public function addColumn(string $name, OrderType $orderType): void
+    public function addColumn(Expression|string $name, OrderType $orderType): void
     {
-        $this->columnsToOrderType[$name] = $orderType;
+        $this->columnsAndOrderTypes[] = [$name, $orderType];
     }
 
 
     public function build(): string
     {
-        if (empty($this->columnsToOrderType)) {
+        if (empty($this->columnsAndOrderTypes)) {
             return '';
         }
-        return 'ORDER BY ' . implode(', ', array_map(function (string $name, OrderType $orderType) {
-                return $name . ' ' . $orderType->value;
-            }, array_keys($this->columnsToOrderType), $this->columnsToOrderType));
+        return 'ORDER BY ' . implode(
+                ', ',
+                array_map(
+                    function ($item) {
+                        return SqlUtils::quoteIdentifier($item[0]) . ' ' . $item[1]->value;
+                    },
+                    $this->columnsAndOrderTypes
+                )
+            );
     }
 }

--- a/src/Grammar/Expression.php
+++ b/src/Grammar/Expression.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Abdulelahragih\QueryBuilder\Grammar;
+
+class Expression
+{
+    public static function make(string $value): Expression
+    {
+        return new Expression($value);
+    }
+
+    public function __construct(private readonly string $value)
+    {
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Grammar/Statements/DeleteStatement.php
+++ b/src/Grammar/Statements/DeleteStatement.php
@@ -4,6 +4,8 @@ namespace Abdulelahragih\QueryBuilder\Grammar\Statements;
 
 use Abdulelahragih\QueryBuilder\Data\QueryBuilderException;
 use Abdulelahragih\QueryBuilder\Grammar\Clauses\WhereClause;
+use Abdulelahragih\QueryBuilder\Grammar\Expression;
+use Abdulelahragih\QueryBuilder\Helpers\SqlUtils;
 use Abdulelahragih\QueryBuilder\Traits\CanBuildClause;
 
 class DeleteStatement implements Statement
@@ -12,16 +14,16 @@ class DeleteStatement implements Statement
     use CanBuildClause;
 
     /**
-     * @param string $table
+     * @param Expression|string $table
      * @param array|null $joinClause
      * @param WhereClause|null $whereClause
      * @param bool $forceDelete
      */
     public function __construct(
-        private readonly string       $table,
-        private readonly ?array       $joinClause = null,
-        private readonly ?WhereClause $whereClause = null,
-        private bool                  $forceDelete = false
+        private readonly Expression|string $table,
+        private readonly ?array            $joinClause = null,
+        private readonly ?WhereClause      $whereClause = null,
+        private bool                       $forceDelete = false
     )
     {
     }
@@ -46,7 +48,7 @@ class DeleteStatement implements Statement
                     'Delete statement without where clause is not allowed. Use force(true) to force delete.');
             }
         }
-        return 'DELETE FROM ' . $this->table .
+        return 'DELETE FROM ' . SqlUtils::quoteIdentifier($this->table) .
             $this->buildOrEmpty($this->joinClause) .
             $this->buildOrEmpty($this->whereClause);
     }

--- a/src/Grammar/Statements/InsertStatement.php
+++ b/src/Grammar/Statements/InsertStatement.php
@@ -2,6 +2,8 @@
 
 namespace Abdulelahragih\QueryBuilder\Grammar\Statements;
 
+use Abdulelahragih\QueryBuilder\Grammar\Expression;
+use Abdulelahragih\QueryBuilder\Helpers\SqlUtils;
 use Abdulelahragih\QueryBuilder\Traits\CanBuildClause;
 
 class InsertStatement implements Statement
@@ -9,16 +11,17 @@ class InsertStatement implements Statement
     use CanBuildClause;
 
     public function __construct(
-        private readonly string $table,
-        private readonly array  $columns,
-        private readonly array  $values,
+        private readonly Expression|string $table,
+        private readonly array             $columns,
+        private readonly array             $values,
     )
     {
     }
 
     public function build(): string
     {
-        return 'INSERT INTO ' . $this->table . ' (' . implode(', ', $this->columns) . ') VALUES ' .
+        $columns = SqlUtils::joinTo($this->columns, ', ', fn($column) => SqlUtils::quoteIdentifier($column));
+        return 'INSERT INTO ' . SqlUtils::quoteIdentifier($this->table) . ' (' . $columns . ') VALUES ' .
             $this->buildValuesClause($this->values);
     }
 

--- a/src/Grammar/Statements/SelectStatement.php
+++ b/src/Grammar/Statements/SelectStatement.php
@@ -9,6 +9,7 @@ use Abdulelahragih\QueryBuilder\Grammar\Clauses\LimitClause;
 use Abdulelahragih\QueryBuilder\Grammar\Clauses\OffsetClause;
 use Abdulelahragih\QueryBuilder\Grammar\Clauses\OrderByClause;
 use Abdulelahragih\QueryBuilder\Grammar\Clauses\WhereClause;
+use Abdulelahragih\QueryBuilder\Helpers\SqlUtils;
 use Abdulelahragih\QueryBuilder\Traits\CanBuildClause;
 
 class SelectStatement implements Statement
@@ -23,6 +24,7 @@ class SelectStatement implements Statement
      * @param LimitClause|null $limitClause
      * @param OffsetClause|null $offsetClause
      * @param OrderByClause|null $orderByClause
+     * @param bool $distinct
      */
     public function __construct(
         private readonly ?FromClause    $fromClause = null,
@@ -32,7 +34,7 @@ class SelectStatement implements Statement
         private readonly ?LimitClause   $limitClause = null,
         private readonly ?OffsetClause  $offsetClause = null,
         private readonly ?OrderByClause $orderByClause = null,
-        private readonly bool $distinct = false
+        private readonly bool           $distinct = false
     )
     {
     }
@@ -53,7 +55,9 @@ class SelectStatement implements Statement
     private function buildSelectQuery(): string
     {
         $distinct = $this->distinct ? 'DISTINCT ' : '';
-        return "SELECT " . $distinct . (empty($this->columns) ? '*' : implode(', ', $this->columns)) .
+        $columns = empty($this->columns) ? '*' :
+            SqlUtils::joinTo($this->columns, ', ', fn($column) => SqlUtils::quoteIdentifier($column));
+        return "SELECT " . $distinct . $columns .
             $this->buildOrEmpty($this->fromClause) .
             $this->buildOrEmpty($this->joinClause) .
             $this->buildOrEmpty($this->whereClause) .

--- a/src/Grammar/Statements/UpdateStatement.php
+++ b/src/Grammar/Statements/UpdateStatement.php
@@ -6,6 +6,8 @@ namespace Abdulelahragih\QueryBuilder\Grammar\Statements;
 use Abdulelahragih\QueryBuilder\Data\QueryBuilderException;
 use Abdulelahragih\QueryBuilder\Grammar\Clauses\Clause;
 use Abdulelahragih\QueryBuilder\Grammar\Clauses\WhereClause;
+use Abdulelahragih\QueryBuilder\Grammar\Expression;
+use Abdulelahragih\QueryBuilder\Helpers\SqlUtils;
 use Abdulelahragih\QueryBuilder\Traits\CanBuildClause;
 
 class UpdateStatement implements Clause
@@ -20,11 +22,11 @@ class UpdateStatement implements Clause
      * @param bool $forceUpdate
      */
     public function __construct(
-        private readonly string       $table,
-        public readonly ?array        $columnsToValues = null,
-        private readonly ?array       $joinClause = null,
-        private readonly ?WhereClause $whereClause = null,
-        private bool                  $forceUpdate = false
+        private readonly Expression|string $table,
+        public readonly ?array             $columnsToValues = null,
+        private readonly ?array            $joinClause = null,
+        private readonly ?WhereClause      $whereClause = null,
+        private bool                       $forceUpdate = false
     )
     {
     }
@@ -49,7 +51,7 @@ class UpdateStatement implements Clause
                     'Update statement without where clause is not allowed. Use force(true) to force update.');
             }
         }
-        return 'UPDATE ' . $this->table . ' SET ' .
+        return 'UPDATE ' . SqlUtils::quoteIdentifier($this->table) . ' SET ' .
             $this->buildSetClause($this->columnsToValues) .
             $this->buildOrEmpty($this->joinClause) .
             $this->buildOrEmpty($this->whereClause);
@@ -57,8 +59,8 @@ class UpdateStatement implements Clause
 
     private function buildSetClause(array $columnsToValues): string
     {
-        return implode(', ', array_map(function ($column, $value) {
-            return $column . ' = ' . $value;
+        return implode(', ', array_map(function (Expression|string $column, string $value) {
+            return SqlUtils::quoteIdentifier($column) . ' = ' . $value;
         }, array_keys($columnsToValues), $columnsToValues));
     }
 }

--- a/src/Helpers/BindingsManager.php
+++ b/src/Helpers/BindingsManager.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Abdulelahragih\QueryBuilder\Helpers;
 
+use Abdulelahragih\QueryBuilder\Grammar\Expression;
+
 class BindingsManager
 {
     protected int $counter = 1;
@@ -10,6 +12,9 @@ class BindingsManager
 
     public function add(mixed $value): string
     {
+        if ($value instanceof Expression) {
+            return $value->getValue();
+        }
         $placeholderKey = ':v' . $this->counter;
         $this->placeholders[substr($placeholderKey, 1)] = $value;
 

--- a/src/Helpers/SqlUtils.php
+++ b/src/Helpers/SqlUtils.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Abdulelahragih\QueryBuilder\Helpers;
+
+use Abdulelahragih\QueryBuilder\Grammar\Expression;
+
+class SqlUtils
+{
+    /**
+     * Joins an array of items with an optional callback to process each item.
+     *
+     * @param array $items The items to join.
+     * @param string $separator The separator for joining.
+     * @param callable|null $callback An optional callback to apply to each item.
+     * @return string The joined string.
+     */
+    public static function joinTo(array $items, string $separator = ', ', ?callable $callback = null): string
+    {
+        // Apply callback to each item if provided
+        $processedItems = $callback ? array_map($callback, $items) : $items;
+
+        // Join the processed items
+        return implode($separator, $processedItems);
+    }
+
+    /**
+     * Escapes and quotes an identifier for SQL queries.
+     *
+     * Handles dotted identifiers like "user.id" and converts them into "`user`.`id`".
+     *
+     * @param Expression|string $identifier The SQL identifier to sanitize such as table or column name.
+     * @return string The sanitized identifier.
+     */
+    public static function quoteIdentifier(Expression|string $identifier): string
+    {
+        if ($identifier instanceof Expression) {
+            return $identifier->getValue();
+        }
+
+        // Split identifiers by dots (e.g., user.id -> ['user', 'id'])
+        $parts = explode('.', $identifier);
+
+        // Quote each part and join them with `.`
+        $quotedParts = array_map(function ($part) {
+            // Check if the part is already enclosed in backticks
+            if (str_starts_with($part, '`') && str_ends_with($part, '`')) {
+                return $part;
+            }
+            // Escape backticks and wrap with backticks
+            return '`' . str_replace('`', '``', $part) . '`';
+        }, $parts);
+
+        return implode('.', $quotedParts);
+    }
+}

--- a/src/Helpers/SqlUtils.php
+++ b/src/Helpers/SqlUtils.php
@@ -16,10 +16,23 @@ class SqlUtils
      */
     public static function joinTo(array $items, string $separator = ', ', ?callable $callback = null): string
     {
-        // Apply callback to each item if provided
         $processedItems = $callback ? array_map($callback, $items) : $items;
 
-        // Join the processed items
+        return implode($separator, $processedItems);
+    }
+
+    /**
+     * Joins an associative array of items with an optional callback to process each item.
+     *
+     * @param array $items The items to join.
+     * @param string $separator The separator for joining.
+     * @param callable|null $callback An optional callback to apply to each item.
+     * @return string The joined string.
+     */
+    public static function joinToAssociative(array $items, string $separator = ', ', ?callable $callback = null): string
+    {
+        $processedItems = $callback ? array_map($callback, array_keys($items), $items) : $items;
+
         return implode($separator, $processedItems);
     }
 

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -13,6 +13,7 @@ use Abdulelahragih\QueryBuilder\Grammar\Clauses\JoinClause;
 use Abdulelahragih\QueryBuilder\Grammar\Clauses\LimitClause;
 use Abdulelahragih\QueryBuilder\Grammar\Clauses\OffsetClause;
 use Abdulelahragih\QueryBuilder\Grammar\Clauses\OrderByClause;
+use Abdulelahragih\QueryBuilder\Grammar\Expression;
 use Abdulelahragih\QueryBuilder\Grammar\Statements\DeleteStatement;
 use Abdulelahragih\QueryBuilder\Grammar\Statements\InsertStatement;
 use Abdulelahragih\QueryBuilder\Grammar\Statements\SelectStatement;
@@ -174,13 +175,13 @@ class QueryBuilder
         return $this->selectClause->build() . $this->queryEndMarker();
     }
 
-    public function table(string $table): self
+    public function table(Expression|string $table): self
     {
         $this->fromClause = new FromClause($table);
         return $this;
     }
 
-    public function select(string ...$columns): self
+    public function select(Expression|string ...$columns): self
     {
         $this->columns = $columns;
         return $this;
@@ -280,7 +281,7 @@ class QueryBuilder
     /**
      * @throws QueryBuilderException
      */
-    public function orderBy(string $column, string $type = 'ASC'): self
+    public function orderBy(Expression|string $column, string $type = 'ASC'): self
     {
         if (!OrderType::contains($type)) {
             throw new QueryBuilderException(QueryBuilderException::INVALID_ORDER_TYPE, 'Invalid order type ' . $type);
@@ -292,7 +293,7 @@ class QueryBuilder
         return $this;
     }
 
-    public function orderByDesc(string $column): self
+    public function orderByDesc(Expression|string $column): self
     {
         if (!isset($this->orderByClause)) {
             $this->orderByClause = new OrderByClause();
@@ -305,11 +306,11 @@ class QueryBuilder
      * @throws QueryBuilderException
      */
     public function join(
-        string         $table,
-        string|Closure $column1,
-        ?string        $operator = null,
-        ?string        $column2 = null,
-        string         $type = 'INNER'
+        Expression|string         $table,
+        Expression|string|Closure $column1,
+        ?string                   $operator = null,
+        Expression|string|null    $column2 = null,
+        string                    $type = 'INNER'
     ): self
     {
         if ($column1 instanceof Closure) {
@@ -331,10 +332,10 @@ class QueryBuilder
      * @throws QueryBuilderException
      */
     public function leftJoin(
-        string         $table,
-        string|Closure $column1,
-        ?string        $operator = null,
-        ?string        $column2 = null,
+        Expression|string         $table,
+        Expression|string|Closure $column1,
+        ?string                   $operator = null,
+        Expression|string|null    $column2 = null,
     ): self
     {
         $this->join($table, $column1, $operator, $column2, 'LEFT');
@@ -345,10 +346,10 @@ class QueryBuilder
      * @throws QueryBuilderException
      */
     public function rightJoin(
-        string         $table,
-        string|Closure $column1,
-        ?string        $operator = null,
-        ?string        $column2 = null,
+        Expression|string         $table,
+        Expression|string|Closure $column1,
+        ?string                   $operator = null,
+        Expression|string|null    $column2 = null,
     ): self
     {
         $this->join($table, $column1, $operator, $column2, 'RIGHT');
@@ -359,10 +360,10 @@ class QueryBuilder
      * @throws QueryBuilderException
      */
     public function fullJoin(
-        string         $table,
-        string|Closure $column1,
-        ?string        $operator = null,
-        ?string        $column2 = null,
+        Expression|string         $table,
+        Expression|string|Closure $column1,
+        ?string                   $operator = null,
+        Expression|string|null    $column2 = null,
     ): self
     {
         $this->join($table, $column1, $operator, $column2, 'FULL');
@@ -370,7 +371,7 @@ class QueryBuilder
     }
 
     public function where(
-        string|Closure             $column,
+        Expression|string|Closure  $column,
         ?string                    $operator = null,
         string|int|float|bool|null $value = null,
         bool                       $and = true
@@ -391,7 +392,7 @@ class QueryBuilder
     }
 
     public function whereLike(
-        string                $column,
+        Expression|string     $column,
         string|int|float|bool $value,
         bool                  $and = true
     ): self
@@ -401,7 +402,7 @@ class QueryBuilder
     }
 
     public function whereNotLike(
-        string                $column,
+        Expression|string     $column,
         string|int|float|bool $value,
         bool                  $and = true
     ): self
@@ -411,9 +412,9 @@ class QueryBuilder
     }
 
     public function whereIn(
-        string $column,
-        array  $values,
-        bool   $and = true
+        Expression|string $column,
+        array             $values,
+        bool              $and = true
     ): self
     {
         $this->whereQueryBuilder->whereIn($column, $values, $and);
@@ -421,9 +422,9 @@ class QueryBuilder
     }
 
     public function whereNotIn(
-        string $column,
-        array  $values,
-        bool   $and = true
+        Expression|string $column,
+        array             $values,
+        bool              $and = true
     ): self
     {
         $this->whereQueryBuilder->whereNotIn($column, $values, $and);
@@ -431,8 +432,8 @@ class QueryBuilder
     }
 
     public function whereNull(
-        string $column,
-        bool   $and = true
+        Expression|string $column,
+        bool              $and = true
     ): self
     {
         $this->whereQueryBuilder->whereNull($column, $and);
@@ -440,8 +441,8 @@ class QueryBuilder
     }
 
     public function whereNotNull(
-        string $column,
-        bool   $and = true
+        Expression|string $column,
+        bool              $and = true
     ): self
     {
         $this->whereQueryBuilder->whereNotNull($column, $and);
@@ -449,7 +450,7 @@ class QueryBuilder
     }
 
     public function whereBetween(
-        string                $column,
+        Expression|string     $column,
         string|int|float|bool $value1,
         string|int|float|bool $value2,
         bool                  $and = true
@@ -460,7 +461,7 @@ class QueryBuilder
     }
 
     public function whereNotBetween(
-        string                $column,
+        Expression|string     $column,
         string|int|float|bool $value1,
         string|int|float|bool $value2,
         bool                  $and = true
@@ -508,6 +509,11 @@ class QueryBuilder
         return ';';
     }
 
+    /**
+     * Allow for custom object conversion after fetching the results
+     * @param Closure $objConverter
+     * @return $this
+     */
     public function objectConverter(Closure $objConverter): self
     {
         $this->objConverter = $objConverter;
@@ -515,6 +521,7 @@ class QueryBuilder
     }
 
     /**
+     * Limit the number of results to 1 and return the first result
      * @throws QueryBuilderException
      */
     public function first(string ...$columns): mixed
@@ -539,6 +546,7 @@ class QueryBuilder
     }
 
     /**
+     * Retrieve a single column from the result
      * @throws QueryBuilderException
      */
     public function pluck(string $column): array
@@ -548,8 +556,22 @@ class QueryBuilder
         return $result->pluck($column);
     }
 
+    /**
+     * Retrieve all the bound values
+     * @return array
+     */
     public function getValues(): array
     {
         return Collection::make($this->bindingsManager->getBindings())->values()->toArray();
+    }
+
+    /**
+     * Allow for raw expressions in the query
+     * @param string $value
+     * @return Expression
+     */
+    public function raw(string $value): Expression
+    {
+        return Expression::make($value);
     }
 }

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -519,7 +519,7 @@ class QueryBuilder
      */
     public function first(string ...$columns): mixed
     {
-        if (!isset($this->selectClause)) {
+        if (empty($this->columns)) {
             $this->select(...$columns);
         }
 

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -18,7 +18,7 @@ class QueryBuilderTest extends TestCase
             ->table('users')
             ->select('id', 'name')
             ->toSql();
-        $this->assertEquals('SELECT id, name FROM users;', $query);
+        $this->assertEquals('SELECT `id`, `name` FROM `users`;', $query);
     }
 
     public function testSimpleWhere()
@@ -29,7 +29,7 @@ class QueryBuilderTest extends TestCase
             ->select('id', 'name')
             ->where('id', '=', 1)
             ->toSql();
-        $this->assertEquals('SELECT id, name FROM users WHERE id = :v1;', $query);
+        $this->assertEquals('SELECT `id`, `name` FROM `users` WHERE `id` = :v1;', $query);
         $this->assertContains(1, $builder->getValues());
     }
 
@@ -42,7 +42,7 @@ class QueryBuilderTest extends TestCase
             ->where('id', '=', 1)
             ->where('name', '=', 'Sam')
             ->toSql();
-        $this->assertEquals('SELECT id, name FROM users WHERE id = :v1 AND name = :v2;', $query);
+        $this->assertEquals('SELECT `id`, `name` FROM `users` WHERE `id` = :v1 AND `name` = :v2;', $query);
         $this->assertContains(1, $builder->getValues());
         $this->assertContains('Sam', $builder->getValues());
     }
@@ -59,7 +59,7 @@ class QueryBuilderTest extends TestCase
                 $builder->where('name', '=', 'Sam');
             })
             ->toSql();
-        $this->assertEquals('SELECT id, name FROM users WHERE id = :v1 OR (id = :v2 AND name = :v3);', $query);
+        $this->assertEquals('SELECT `id`, `name` FROM `users` WHERE `id` = :v1 OR (`id` = :v2 AND `name` = :v3);', $query);
         $this->assertContains(1, $builder->getValues());
         $this->assertContains(2, $builder->getValues());
         $this->assertContains('Sam', $builder->getValues());
@@ -81,7 +81,7 @@ class QueryBuilderTest extends TestCase
                 });
             })
             ->toSql();
-        $this->assertEquals('SELECT id, name FROM users WHERE id = :v1 OR (id = :v2 AND name = :v3 AND (id = :v4 OR name = :v5));', $query);
+        $this->assertEquals('SELECT `id`, `name` FROM `users` WHERE `id` = :v1 OR (`id` = :v2 AND `name` = :v3 AND (`id` = :v4 OR `name` = :v5));', $query);
         $this->assertContains(1, $builder->getValues());
         $this->assertContains(2, $builder->getValues());
         $this->assertContains('Sam', $builder->getValues());
@@ -96,7 +96,7 @@ class QueryBuilderTest extends TestCase
             ->table('users')
             ->whereIn('id', [1, 2, 3, 4, 5])
             ->toSql();
-        $this->assertEquals('SELECT * FROM users WHERE id IN (:v1, :v2, :v3, :v4, :v5);', $query);
+        $this->assertEquals('SELECT * FROM `users` WHERE `id` IN (:v1, :v2, :v3, :v4, :v5);', $query);
         $this->assertEquals([1, 2, 3, 4, 5], $builder->getValues());
     }
 
@@ -107,7 +107,7 @@ class QueryBuilderTest extends TestCase
             ->table('users')
             ->whereNotIn('id', [1, 2, 3, 4, 5])
             ->toSql();
-        $this->assertEquals('SELECT * FROM users WHERE id NOT IN (:v1, :v2, :v3, :v4, :v5);', $query);
+        $this->assertEquals('SELECT * FROM `users` WHERE `id` NOT IN (:v1, :v2, :v3, :v4, :v5);', $query);
         $this->assertEquals([1, 2, 3, 4, 5], $builder->getValues());
     }
 
@@ -118,7 +118,7 @@ class QueryBuilderTest extends TestCase
             ->table('users')
             ->whereLike('name', 'Sam')
             ->toSql();
-        $this->assertEquals('SELECT * FROM users WHERE name LIKE :v1;', $query);
+        $this->assertEquals('SELECT * FROM `users` WHERE `name` LIKE :v1;', $query);
         $this->assertEquals('Sam', $builder->getValues()[0]);
     }
 
@@ -129,7 +129,7 @@ class QueryBuilderTest extends TestCase
             ->table('users')
             ->whereNotLike('name', 'Sam')
             ->toSql();
-        $this->assertEquals('SELECT * FROM users WHERE name NOT LIKE :v1;', $query);
+        $this->assertEquals('SELECT * FROM `users` WHERE `name` NOT LIKE :v1;', $query);
         $this->assertEquals('Sam', $builder->getValues()[0]);
     }
 
@@ -140,7 +140,7 @@ class QueryBuilderTest extends TestCase
             ->table('users')
             ->whereLike('name', '%Sam%')
             ->toSql();
-        $this->assertEquals('SELECT * FROM users WHERE name LIKE :v1;', $query);
+        $this->assertEquals('SELECT * FROM `users` WHERE `name` LIKE :v1;', $query);
         $this->assertEquals('%Sam%', $builder->getValues()[0]);
     }
 
@@ -151,7 +151,7 @@ class QueryBuilderTest extends TestCase
             ->table('users')
             ->whereNull('name')
             ->toSql();
-        $this->assertEquals('SELECT * FROM users WHERE name IS NULL;', $query);
+        $this->assertEquals('SELECT * FROM `users` WHERE `name` IS NULL;', $query);
     }
 
     public function testWhereNotNull()
@@ -161,7 +161,7 @@ class QueryBuilderTest extends TestCase
             ->table('users')
             ->whereNotNull('name')
             ->toSql();
-        $this->assertEquals('SELECT * FROM users WHERE name IS NOT NULL;', $query);
+        $this->assertEquals('SELECT * FROM `users` WHERE `name` IS NOT NULL;', $query);
     }
 
     public function testWhereBetween()
@@ -171,7 +171,7 @@ class QueryBuilderTest extends TestCase
             ->table('users')
             ->whereBetween('id', 1, 10)
             ->toSql();
-        $this->assertEquals('SELECT * FROM users WHERE id BETWEEN :v1 AND :v2;', $query);
+        $this->assertEquals('SELECT * FROM `users` WHERE `id` BETWEEN :v1 AND :v2;', $query);
         $this->assertEquals(1, $builder->getValues()[0]);
         $this->assertEquals(10, $builder->getValues()[1]);
     }
@@ -183,7 +183,7 @@ class QueryBuilderTest extends TestCase
             ->table('users')
             ->whereNotBetween('id', 1, 10)
             ->toSql();
-        $this->assertEquals('SELECT * FROM users WHERE id NOT BETWEEN :v1 AND :v2;', $query);
+        $this->assertEquals('SELECT * FROM `users` WHERE `id` NOT BETWEEN :v1 AND :v2;', $query);
         $this->assertEquals(1, $builder->getValues()[0]);
         $this->assertEquals(10, $builder->getValues()[1]);
     }
@@ -197,7 +197,7 @@ class QueryBuilderTest extends TestCase
             ->orderBy('id')
             ->orderBy('name')
             ->toSql();
-        $this->assertEquals('SELECT id, name FROM users ORDER BY id ASC, name ASC;', $query);
+        $this->assertEquals('SELECT `id`, `name` FROM `users` ORDER BY `id` ASC, `name` ASC;', $query);
     }
 
     public function testOrderByDescending()
@@ -209,10 +209,11 @@ class QueryBuilderTest extends TestCase
             ->orderByDesc('id')
             ->orderByDesc('name')
             ->toSql();
-        $this->assertEquals('SELECT id, name FROM users ORDER BY id DESC, name DESC;', $query);
+        $this->assertEquals('SELECT `id`, `name` FROM `users` ORDER BY `id` DESC, `name` DESC;', $query);
     }
 
-    public function testMixedOrder() {
+    public function testMixedOrder()
+    {
         $builder = new QueryBuilder($this->pdo);
         $query = $builder
             ->table('users')
@@ -220,7 +221,7 @@ class QueryBuilderTest extends TestCase
             ->orderBy('id')
             ->orderByDesc('name')
             ->toSql();
-        $this->assertEquals('SELECT id, name FROM users ORDER BY id ASC, name DESC;', $query);
+        $this->assertEquals('SELECT `id`, `name` FROM `users` ORDER BY `id` ASC, `name` DESC;', $query);
     }
 
     public function testLimit()
@@ -231,7 +232,7 @@ class QueryBuilderTest extends TestCase
             ->select('id', 'name')
             ->limit(10)
             ->toSql();
-        $this->assertEquals('SELECT id, name FROM users LIMIT 10;', $query);
+        $this->assertEquals('SELECT `id`, `name` FROM `users` LIMIT 10;', $query);
     }
 
     public function testOffset()
@@ -242,7 +243,7 @@ class QueryBuilderTest extends TestCase
             ->select('id', 'name')
             ->offset(10)
             ->toSql();
-        $this->assertEquals('SELECT id, name FROM users OFFSET 10;', $query);
+        $this->assertEquals('SELECT `id`, `name` FROM `users` OFFSET 10;', $query);
     }
 
     public function testLimitAndOffset()
@@ -254,7 +255,7 @@ class QueryBuilderTest extends TestCase
             ->limit(10)
             ->offset(10)
             ->toSql();
-        $this->assertEquals('SELECT id, name FROM users LIMIT 10 OFFSET 10;', $query);
+        $this->assertEquals('SELECT `id`, `name` FROM `users` LIMIT 10 OFFSET 10;', $query);
     }
 
     public function testInnerJoin()
@@ -264,7 +265,7 @@ class QueryBuilderTest extends TestCase
             ->table('users')
             ->join('images', 'images.user_id', '=', 'users.id')
             ->toSql();
-        $this->assertEquals('SELECT * FROM users INNER JOIN images ON images.user_id = users.id;', $query);
+        $this->assertEquals('SELECT * FROM `users` INNER JOIN `images` ON `images`.`user_id` = `users`.`id`;', $query);
     }
 
     public function testLeftJoin()
@@ -274,7 +275,7 @@ class QueryBuilderTest extends TestCase
             ->table('users')
             ->leftJoin('images', 'images.user_id', '=', 'users.id')
             ->toSql();
-        $this->assertEquals('SELECT * FROM users LEFT JOIN images ON images.user_id = users.id;', $query);
+        $this->assertEquals('SELECT * FROM `users` LEFT JOIN `images` ON `images`.`user_id` = `users`.`id`;', $query);
     }
 
     public function testRightJoin()
@@ -284,7 +285,7 @@ class QueryBuilderTest extends TestCase
             ->table('users')
             ->rightJoin('images', 'images.user_id', '=', 'users.id')
             ->toSql();
-        $this->assertEquals('SELECT * FROM users RIGHT JOIN images ON images.user_id = users.id;', $query);
+        $this->assertEquals('SELECT * FROM `users` RIGHT JOIN `images` ON `images`.`user_id` = `users`.`id`;', $query);
     }
 
     public function testNestedJoinConditions()
@@ -301,8 +302,8 @@ class QueryBuilderTest extends TestCase
                 });
             })
             ->toSql();
-        $this->assertEquals('SELECT * FROM users INNER JOIN images ON images.user_id = users.id OR ' .
-            'images.user_id = :v1 AND (images.user_id = :v2 OR images.id = :v3);', $query);
+        $this->assertEquals('SELECT * FROM `users` INNER JOIN `images` ON `images`.`user_id` = `users`.`id` OR ' .
+            '`images`.`user_id` = :v1 AND (`images`.`user_id` = :v2 OR `images`.`id` = :v3);', $query);
     }
 
     public function testFirst()
@@ -323,6 +324,7 @@ class QueryBuilderTest extends TestCase
             ->first('name'); // ignore first columns
         $this->assertEquals(1, $result);
     }
+
     public function testPluck()
     {
         $builder = new QueryBuilder($this->pdo);
@@ -345,7 +347,7 @@ class QueryBuilderTest extends TestCase
                     'name' => 'John'
                 ],
                 $query);
-        $this->assertEquals('INSERT INTO users (id, name) VALUES (:v1, :v2);', $query);
+        $this->assertEquals('INSERT INTO `users` (`id`, `name`) VALUES (:v1, :v2);', $query);
         $name = $builder->table('users')->where('id', '=', 100)->first('name');
         $this->assertEquals('John', $name);
     }
@@ -368,7 +370,7 @@ class QueryBuilderTest extends TestCase
                     ]
                 ],
                 $query);
-        $this->assertEquals('INSERT INTO users (id, name) VALUES (:v1, :v2), (:v3, :v4);', $query);
+        $this->assertEquals('INSERT INTO `users` (`id`, `name`) VALUES (:v1, :v2), (:v3, :v4);', $query);
         $name = $builder->table('users')->where('id', '=', 100)->first('name');
         $this->assertEquals('John', $name);
         $name = $builder->table('users')->where('id', '=', 101)->first('name');
@@ -387,7 +389,7 @@ class QueryBuilderTest extends TestCase
                     'name' => 'Sarah'
                 ],
                 $query);
-        $this->assertEquals('UPDATE users SET name = :v2 WHERE id = :v1;', $query);
+        $this->assertEquals('UPDATE `users` SET `name` = :v2 WHERE `id` = :v1;', $query);
         $name = $builder->table('users')->where('id', '=', 1)->first('name');
         $this->assertEquals('Sarah', $name);
     }
@@ -401,20 +403,21 @@ class QueryBuilderTest extends TestCase
             ->where('id', '=', 1)
             ->orWhere('id', '=', 2)
             ->delete($query);
-        $this->assertEquals('DELETE FROM users WHERE id = :v1 OR id = :v2;', $query);
+        $this->assertEquals('DELETE FROM `users` WHERE `id` = :v1 OR `id` = :v2;', $query);
         $name = $builder->table('users')->where('id', '=', 1)->first('name');
         $this->assertNull($name);
         $name = $builder->table('users')->where('id', '=', 2)->first('name');
         $this->assertNull($name);
     }
 
-    public function testEmptyWhereIn() {
+    public function testEmptyWhereIn()
+    {
         $builder = new QueryBuilder($this->pdo);
         $query = $builder
             ->table('users')
             ->whereIn('id', [])
             ->toSql();
-        $this->assertEquals('SELECT * FROM users WHERE 1 = 0;', $query);
+        $this->assertEquals('SELECT * FROM `users` WHERE 1 = 0;', $query);
     }
 
     public function testDistinct()
@@ -425,7 +428,184 @@ class QueryBuilderTest extends TestCase
             ->distinct()
             ->select('id')
             ->toSql();
-        $this->assertEquals('SELECT DISTINCT id FROM users;', $query);
+        $this->assertEquals('SELECT DISTINCT `id` FROM `users`;', $query);
     }
 
+    public function testRawExpressionInSelect()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $query = $builder
+            ->table('users')
+            ->select('id', 'name', $builder->raw('COUNT(*) as count'))
+            ->toSql();
+        $this->assertEquals('SELECT `id`, `name`, COUNT(*) as count FROM `users`;', $query);
+    }
+
+    public function testRawExpressionInTableName()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $query = $builder
+            ->table($builder->raw('users'))
+            ->select('id', 'name')
+            ->toSql();
+        $this->assertEquals('SELECT `id`, `name` FROM users;', $query);
+    }
+
+    public function testRawExpressionInWhere()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $query = $builder
+            ->table('users')
+            ->where($builder->raw('1'), '=', 1)
+            ->toSql();
+        $this->assertEquals('SELECT * FROM `users` WHERE 1 = :v1;', $query);
+    }
+
+    public function testRawExpressionInWhereIn()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $query = $builder
+            ->table('users')
+            ->whereIn($builder->raw('id'), [1, 2])
+            ->toSql();
+        $this->assertEquals('SELECT * FROM `users` WHERE id IN (:v1, :v2);', $query);
+    }
+
+    public function testRawExpressionInWhereNotIn()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $query = $builder
+            ->table('users')
+            ->whereNotIn($builder->raw('id'), [1, 2])
+            ->toSql();
+        $this->assertEquals('SELECT * FROM `users` WHERE id NOT IN (:v1, :v2);', $query);
+    }
+
+    public function testRawExpressionInWhereLike()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $query = $builder
+            ->table('users')
+            ->whereLike($builder->raw('name'), 'Sam')
+            ->toSql();
+        $this->assertEquals('SELECT * FROM `users` WHERE name LIKE :v1;', $query);
+    }
+
+    public function testRawExpressionInWhereNotLike()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $query = $builder
+            ->table('users')
+            ->whereNotLike($builder->raw('name'), 'Sam')
+            ->toSql();
+        $this->assertEquals('SELECT * FROM `users` WHERE name NOT LIKE :v1;', $query);
+    }
+
+    public function testRawExpressionInWhereNull()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $query = $builder
+            ->table('users')
+            ->whereNull($builder->raw('name'))
+            ->toSql();
+        $this->assertEquals('SELECT * FROM `users` WHERE name IS NULL;', $query);
+    }
+
+    public function testRawExpressionInWhereNotNull()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $query = $builder
+            ->table('users')
+            ->whereNotNull($builder->raw('name'))
+            ->toSql();
+        $this->assertEquals('SELECT * FROM `users` WHERE name IS NOT NULL;', $query);
+    }
+
+    public function testRawExpressionInWhereBetween()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $query = $builder
+            ->table('users')
+            ->whereBetween($builder->raw('id'), 1, 10)
+            ->toSql();
+        $this->assertEquals('SELECT * FROM `users` WHERE id BETWEEN :v1 AND :v2;', $query);
+    }
+
+    public function testRawExpressionInWhereNotBetween()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $query = $builder
+            ->table('users')
+            ->whereNotBetween($builder->raw('id'), 1, 10)
+            ->toSql();
+        $this->assertEquals('SELECT * FROM `users` WHERE id NOT BETWEEN :v1 AND :v2;', $query);
+    }
+
+    public function testRawExpressionInOrderBy()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $query = $builder
+            ->table('users')
+            ->orderBy($builder->raw('id'))
+            ->toSql();
+        $this->assertEquals('SELECT * FROM `users` ORDER BY id ASC;', $query);
+    }
+
+    public function testRawExpressionInJoin()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $query = $builder
+            ->table('users')
+            ->join($builder->raw('images'), 'images.user_id', '=', 'users.id')
+            ->toSql();
+        $this->assertEquals('SELECT * FROM `users` INNER JOIN images ON `images`.`user_id` = `users`.`id`;', $query);
+    }
+
+    public function testRawExpressionInNestedWhereConditions()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $query = $builder
+            ->table('users')
+            ->where('id', '=', 1)
+            ->orWhere(function (WhereQueryBuilder $builder) {
+                $builder->where($builder->raw('id'), '=', 2);
+                $builder->where('name', '=', 'Sam');
+            })
+            ->toSql();
+        $this->assertEquals('SELECT * FROM `users` WHERE `id` = :v1 OR (id = :v2 AND `name` = :v3);', $query);
+    }
+
+    public function testRawExpressionInInsert()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $query = null;
+        $builder
+            ->table('users')
+            ->insert(
+                [
+                    'id' => 100,
+                    'name' => $builder->raw('"John" || " Doe"')
+                ],
+                $query);
+        $this->assertEquals('INSERT INTO `users` (`id`, `name`) VALUES (:v1, "John" || " Doe");', $query);
+        $name = $builder->table('users')->where('id', '=', 100)->first('name');
+        $this->assertEquals('John Doe', $name);
+    }
+
+    public function testRawExpressionInUpdate()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $query = null;
+        $builder
+            ->table('users')
+            ->where('id', '=', 1)
+            ->update(
+                [
+                    'name' => $builder->raw('"Sarah" || " Connor"')
+                ],
+                $query);
+        $this->assertEquals('UPDATE `users` SET `name` = "Sarah" || " Connor" WHERE `id` = :v1;', $query);
+        $name = $builder->table('users')->where('id', '=', 1)->first('name');
+        $this->assertEquals('Sarah Connor', $name);
+    }
 }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -6,6 +6,8 @@ use Abdulelahragih\QueryBuilder\Builders\JoinClauseBuilder;
 use Abdulelahragih\QueryBuilder\Builders\WhereQueryBuilder;
 use Abdulelahragih\QueryBuilder\QueryBuilder;
 use Abdulelahragih\QueryBuilder\Tests\Traits\TestTrait;
+use Error;
+use Exception;
 use PHPUnit\Framework\TestCase;
 
 class QueryBuilderTest extends TestCase
@@ -375,6 +377,28 @@ class QueryBuilderTest extends TestCase
         $this->assertEquals('John', $name);
         $name = $builder->table('users')->where('id', '=', 101)->first('name');
         $this->assertEquals('Jane', $name);
+    }
+
+    public function testUpsert()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $query = null;
+        try {
+            $builder
+                ->table('users')
+                ->upsert(
+                    [
+                        'id' => 100,
+                        'name' => 'John'
+                    ],
+                    [
+                        'name' => 'Jane'
+                    ],
+                    $query);
+        } catch (Exception|Error) {
+        }
+
+        $this->assertEquals('INSERT INTO `users` (`id`, `name`) VALUES (:v1, :v2) ON DUPLICATE KEY UPDATE `name` = :v3;', $query);
     }
 
     public function testUpdate()

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -314,6 +314,15 @@ class QueryBuilderTest extends TestCase
         $this->assertEquals(1, $result);
     }
 
+    public function testFirstWithSelect()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder
+            ->table('users')
+            ->select('id')
+            ->first('name'); // ignore first columns
+        $this->assertEquals(1, $result);
+    }
     public function testPluck()
     {
         $builder = new QueryBuilder($this->pdo);

--- a/tests/Traits/TestTrait.php
+++ b/tests/Traits/TestTrait.php
@@ -2,6 +2,7 @@
 
 namespace Abdulelahragih\QueryBuilder\Tests\Traits;
 
+use Exception;
 use PDO;
 
 trait TestTrait


### PR DESCRIPTION
This pull request includes significant changes to the `QueryBuilder` library, focusing on enhancing the flexibility and safety of SQL query construction by introducing the `Expression` class. The changes also involve updating various methods and classes to support this new class.

### Introduction of `Expression` class:
* Added the `Expression` class to encapsulate raw SQL expressions, ensuring they are safely constructed and used throughout the query builder. (`src/Grammar/Expression.php`)

### Updates to `JoinClauseBuilder`:
* Modified the `JoinClauseBuilder` to accept `Expression` objects for table names and column values, enhancing the flexibility of join conditions. (`src/Builders/JoinClauseBuilder.php`) [[1]](diffhunk://#diff-60867f80cbd93ee810ff2a7f1e0a0747b6ab98c8004576732509cc8318829d34L22-R26) [[2]](diffhunk://#diff-60867f80cbd93ee810ff2a7f1e0a0747b6ab98c8004576732509cc8318829d34L34-R41) [[3]](diffhunk://#diff-60867f80cbd93ee810ff2a7f1e0a0747b6ab98c8004576732509cc8318829d34L47-R50) [[4]](diffhunk://#diff-60867f80cbd93ee810ff2a7f1e0a0747b6ab98c8004576732509cc8318829d34L68-R83) [[5]](diffhunk://#diff-60867f80cbd93ee810ff2a7f1e0a0747b6ab98c8004576732509cc8318829d34L88-R109)

### Updates to `WhereQueryBuilder`:
* Updated the `WhereQueryBuilder` to support `Expression` objects for column names and values in various `where` methods, improving the handling of complex conditions. (`src/Builders/WhereQueryBuilder.php`) [[1]](diffhunk://#diff-ea02090c2236065a0912c273cd77fec6cb044dd50b069f3bd6507c8f31c8f216L56-R57) [[2]](diffhunk://#diff-ea02090c2236065a0912c273cd77fec6cb044dd50b069f3bd6507c8f31c8f216L75-R114) [[3]](diffhunk://#diff-ea02090c2236065a0912c273cd77fec6cb044dd50b069f3bd6507c8f31c8f216L124-R146) [[4]](diffhunk://#diff-ea02090c2236065a0912c273cd77fec6cb044dd50b069f3bd6507c8f31c8f216L163-R190) [[5]](diffhunk://#diff-ea02090c2236065a0912c273cd77fec6cb044dd50b069f3bd6507c8f31c8f216L202-R209) [[6]](diffhunk://#diff-ea02090c2236065a0912c273cd77fec6cb044dd50b069f3bd6507c8f31c8f216L221-R230)

### Updates to SQL Clauses:
* Enhanced multiple SQL clauses (`Condition`, `FromClause`, `JoinClause`, `OrderByClause`) to utilize the `Expression` class, ensuring consistent and safe SQL generation. (`src/Grammar/Clauses/Condition.php`) [[1]](diffhunk://#diff-9899c012894c5434f8bf950780166195dc6193b24b874d9e674261ad70e9004dR6-R29) [[2]](diffhunk://#diff-9899c012894c5434f8bf950780166195dc6193b24b874d9e674261ad70e9004dL34-R38) (`src/Grammar/Clauses/FromClause.php`) [[3]](diffhunk://#diff-d52583e11f58a6dc28f403b9ac1d21e20a83191d6f768f6850972fa7acba63edR5-R17) (`src/Grammar/Clauses/JoinClause.php`) [[4]](diffhunk://#diff-c81c3ac1abc8a3654d6f3eeeb7abfd5573a19e715e4e503982095b18a9afcb2aR6-R21) [[5]](diffhunk://#diff-c81c3ac1abc8a3654d6f3eeeb7abfd5573a19e715e4e503982095b18a9afcb2aL32-R34) (`src/Grammar/Clauses/OrderByClause.php`) [[6]](diffhunk://#diff-847f7ee04eb49130c329116affd7879fdb5a2f5ad09ea1c1ec1d114992585610R5-R38)

### Miscellaneous:
* Removed the beta warning from the `README.md` file, indicating the library is now stable for production use. (`README.md`)
* Added `raw` method to various classes (`DB`, `DBSingleton`, `JoinClauseBuilder`, `WhereQueryBuilder`) to create `Expression` objects directly. (`src/DB.php`) [[1]](diffhunk://#diff-1bcc3d63e57bcf662901b8c742e60167d6159e4527963071e8471a3b6c6d7178R89-R93) (`src/DBSingleton.php`) [[2]](diffhunk://#diff-02ef43c0f6f197743f2fe622de6f496ddcab0919478d06ef8199a29de8693a10R81-R85) (`src/Builders/JoinClauseBuilder.php`) [[3]](diffhunk://#diff-60867f80cbd93ee810ff2a7f1e0a0747b6ab98c8004576732509cc8318829d34L88-R109) (`src/Builders/WhereQueryBuilder.php`) [[4]](diffhunk://#diff-ea02090c2236065a0912c273cd77fec6cb044dd50b069f3bd6507c8f31c8f216L221-R230)