### PR TITLE
add support for multiple updates in upsert

### DIFF
--- a/src/Grammar/Statements/InsertStatement.php
+++ b/src/Grammar/Statements/InsertStatement.php
@@ -48,7 +48,12 @@ class InsertStatement implements Statement
         if (empty($this->updateOnDuplicateKey)) {
             return '';
         }
-        $updateColumns = SqlUtils::joinToAssociative($this->updateOnDuplicateKey, ', ', function ($column, $value) {
+        $index = 0;
+        $updateColumns = SqlUtils::joinToAssociative($this->updateOnDuplicateKey, ', ', function ($column, $value) use (&$index) {
+            if (is_int($column) && $column === $index) {
+                $index++;
+                return SqlUtils::quoteIdentifier($value) . ' = ' . 'VALUES(' . SqlUtils::quoteIdentifier($value) . ')';
+            }
             return SqlUtils::quoteIdentifier($column) . ' = ' . $value;
         });
         return ' ON DUPLICATE KEY UPDATE ' . $updateColumns;

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -277,6 +277,9 @@ class QueryBuilder
 
             if (!empty($updateOnDuplicate)) {
                 foreach ($updateOnDuplicate as $column => $value) {
+                    if (is_int($column)) {
+                        continue;
+                    }
                     $updateOnDuplicate[$column] = $this->bindingsManager->add($value);
                 }
             } elseif ($updateOnDuplicate === []) {

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -392,13 +392,60 @@ class QueryBuilderTest extends TestCase
                         'name' => 'John'
                     ],
                     [
-                        'name' => 'Jane'
+                        'name'
                     ],
                     $query);
         } catch (Exception|Error) {
         }
 
+        $this->assertEquals('INSERT INTO `users` (`id`, `name`) VALUES (:v1, :v2) ON DUPLICATE KEY UPDATE `name` = VALUES(`name`);', $query);
+    }
+
+    public function testUpsertWithCustomValueOnUpdate()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $query = null;
+        try {
+            $builder
+                ->table('users')
+                ->upsert(
+                    [
+                        'id' => 100,
+                        'name' => 'John'
+                    ],
+                    [
+                        'name' => 'Jane'
+                    ],
+                    $query);
+        } catch (Exception|Error) {
+        }
+        echo $query;
+
         $this->assertEquals('INSERT INTO `users` (`id`, `name`) VALUES (:v1, :v2) ON DUPLICATE KEY UPDATE `name` = :v3;', $query);
+    }
+
+    public function testUpsertMultipleRows()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $query = null;
+        try {
+            $builder
+                ->table('users')
+                ->upsert(
+                    [
+                        ['id' => 100, 'name' => 'John'],
+                        ['id' => 101, 'name' => 'Jane']
+                    ],
+                    ['name'],
+                    $query
+                );
+        } catch (Exception|Error) {
+        }
+
+        $this->assertEquals(
+            'INSERT INTO `users` (`id`, `name`) VALUES (:v1, :v2), (:v3, :v4) ON DUPLICATE KEY UPDATE `name` = VALUES(`name`);',
+            $query
+        );
     }
 
     public function testUpdate()


### PR DESCRIPTION
This pull request includes several changes to improve the handling of `ON DUPLICATE KEY UPDATE` clauses and add new tests for the `upsert` functionality in the `QueryBuilder`. The most important changes include updates to the `buildOnDuplicateKeyUpdateClause` method, modifications to the `upsert` method to handle integer keys, and the addition of new test cases.

Improvements to `ON DUPLICATE KEY UPDATE` handling:

* [`src/Grammar/Statements/InsertStatement.php`](diffhunk://#diff-0edcd2726ad79d77bde3835ff69e18ec687f54734aeeed5e291bed438863d99eL51-R56): Updated the `buildOnDuplicateKeyUpdateClause` method to handle cases where the column is an integer key, ensuring proper quoting and value assignment.

Enhancements to `upsert` method:

* [`src/QueryBuilder.php`](diffhunk://#diff-ead128612c59bb4a22cd5af177cfc3e31a2f9d7781398300dad342dfc742de0bR280-R282): Modified the `upsert` method to skip integer keys in the `updateOnDuplicate` array, preventing unnecessary binding additions.

Addition of new test cases:

* [`tests/QueryBuilderTest.php`](diffhunk://#diff-d7f20e092910bce0f91a309423646ccdbb46c9124b6fa6964e5d1c1ca75dff85R383-R404): Added a new test case `testUpsert` to verify the correct query generation for single row upserts with default values.
* [`tests/QueryBuilderTest.php`](diffhunk://#diff-d7f20e092910bce0f91a309423646ccdbb46c9124b6fa6964e5d1c1ca75dff85R422-R450): Added a new test case `testUpsertMultipleRows` to verify the correct query generation for multiple row upserts with default values.