### PR TITLE
fix issue with aliased identifiers

### DIFF
--- a/src/Helpers/SqlUtils.php
+++ b/src/Helpers/SqlUtils.php
@@ -50,6 +50,13 @@ class SqlUtils
             return $identifier->getValue();
         }
 
+        if (SqlUtils::isAliased($identifier)) {
+            // Split the identifier and alias
+            [$identifier, $alias] = explode(' AS ', $identifier);
+
+            // Quote the identifier and alias separately
+            return SqlUtils::quoteIdentifier($identifier) . ' AS ' . SqlUtils::quoteIdentifier($alias);
+        }
         // Split identifiers by dots (e.g., user.id -> ['user', 'id'])
         $parts = explode('.', $identifier);
 
@@ -64,5 +71,10 @@ class SqlUtils
         }, $parts);
 
         return implode('.', $quotedParts);
+    }
+
+    private static function isAliased(Expression|string $identifier): bool
+    {
+        return str_contains(strtolower($identifier), ' as ');
     }
 }

--- a/src/Helpers/SqlUtils.php
+++ b/src/Helpers/SqlUtils.php
@@ -66,6 +66,9 @@ class SqlUtils
             if (str_starts_with($part, '`') && str_ends_with($part, '`')) {
                 return $part;
             }
+            if ($part === '*') {
+                return $part;
+            }
             // Escape backticks and wrap with backticks
             return '`' . str_replace('`', '``', $part) . '`';
         }, $parts);

--- a/src/Helpers/SqlUtils.php
+++ b/src/Helpers/SqlUtils.php
@@ -52,7 +52,11 @@ class SqlUtils
 
         if (SqlUtils::isAliased($identifier)) {
             // Split the identifier and alias
-            [$identifier, $alias] = explode(' AS ', $identifier);
+            if (str_contains($identifier, ' AS ')) {
+                [$identifier, $alias] = explode(' AS ', $identifier);
+            } else {
+                [$identifier, $alias] = explode(' as ', $identifier);
+            }
 
             // Quote the identifier and alias separately
             return SqlUtils::quoteIdentifier($identifier) . ' AS ' . SqlUtils::quoteIdentifier($alias);

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -679,4 +679,14 @@ class QueryBuilderTest extends TestCase
         $name = $builder->table('users')->where('id', '=', 1)->first('name');
         $this->assertEquals('Sarah Connor', $name);
     }
+
+    public function testAliasedTable()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $query = $builder
+            ->table('users AS u')
+            ->select('u.id', 'u.name')
+            ->toSql();
+        $this->assertEquals('SELECT `u`.`id`, `u`.`name` FROM `users` AS `u`;', $query);
+    }
 }


### PR DESCRIPTION
This pull request includes changes to the `quoteIdentifier` function in `SqlUtils.php` to handle aliased identifiers, and adds a corresponding test case in `QueryBuilderTest.php`. The most important changes are:

Improvements to `quoteIdentifier` function:

* [`src/Helpers/SqlUtils.php`](diffhunk://#diff-1e5d9528a5af296c1c711ea1e11b3f0b719c7660df8cb35eb1e59484f77e2807R53-R59): Added logic to handle aliased identifiers by splitting and quoting the identifier and alias separately.
* [`src/Helpers/SqlUtils.php`](diffhunk://#diff-1e5d9528a5af296c1c711ea1e11b3f0b719c7660df8cb35eb1e59484f77e2807R75-R79): Introduced a new private method `isAliased` to check if an identifier contains an alias.

New test case:

* [`tests/QueryBuilderTest.php`](diffhunk://#diff-d7f20e092910bce0f91a309423646ccdbb46c9124b6fa6964e5d1c1ca75dff85R682-R691): Added a new test `testAliasedTable` to verify that the `quoteIdentifier` function correctly handles aliased table names.