### PR TITLE
Dev > Main

### DIFF
--- a/src/Helpers/SqlUtils.php
+++ b/src/Helpers/SqlUtils.php
@@ -50,6 +50,7 @@ class SqlUtils
             return $identifier->getValue();
         }
 
+        $matches = null;
         if (SqlUtils::isAliasedWithAs($identifier)) {
             // Split the identifier and alias
             if (str_contains($identifier, ' AS ')) {
@@ -60,12 +61,10 @@ class SqlUtils
 
             // Quote the identifier and alias separately
             return SqlUtils::quoteIdentifier($identifier) . ' AS ' . SqlUtils::quoteIdentifier($alias);
-        } elseif (SqlUtils::isAliasedWithSpace($identifier)) {
+        } elseif (SqlUtils::isAliasedWithSpace($identifier, $matches)) {
             // Split the identifier and alias by the last space
-            $parts = preg_split('/\s+/', $identifier, 2);
-
-            $quotedIdentifier = self::quoteIdentifier($parts[0]);
-            $quotedAlias = self::quoteIdentifier($parts[1]);
+            $quotedIdentifier = self::quoteIdentifier($matches[1]);
+            $quotedAlias = self::quoteIdentifier($matches[2]);
 
             return $quotedIdentifier . ' ' . $quotedAlias;
         }
@@ -89,8 +88,8 @@ class SqlUtils
         return str_contains(strtolower($identifier), ' as ');
     }
 
-    private static function isAliasedWithSpace(string $identifier): bool
+    private static function isAliasedWithSpace(string $identifier, &$matches = null): bool
     {
-        return preg_match('/\s+/', $identifier);
+        return preg_match('/^(\s*(?:[^ \t\n\r`]+|`[^`]+`))\s+((?:[^ \t\n\r`]+|`[^`]+`)\s*)$/', $identifier, $matches);
     }
 }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -756,4 +756,12 @@ class QueryBuilderTest extends TestCase
         $this->assertEquals('SELECT ``id``, ``name`` FROM ``users``;', $query);
     }
 
+    public function testSpaceEscaping() {
+        $builder = new QueryBuilder($this->pdo);
+        $query = $builder
+            ->table(' users ')
+            ->select(' id  ` uid`', 'name ')
+            ->toSql();
+        $this->assertEquals('SELECT ` id` `` uid``, `name ` FROM ` users `;', $query);
+    }
 }


### PR DESCRIPTION
This pull request includes several changes to the `SqlUtils` class and its associated tests to improve the handling of aliased identifiers. The most important changes include modifications to the `quoteIdentifier` method, updates to the `isAliasedWithSpace` method, and the addition of a new test case.

Improvements to `quoteIdentifier` method:

* [`src/Helpers/SqlUtils.php`](diffhunk://#diff-1e5d9528a5af296c1c711ea1e11b3f0b719c7660df8cb35eb1e59484f77e2807L63-R67): Added a `$matches` parameter to the `isAliasedWithSpace` method call and updated the logic to use the matches for quoting identifiers and aliases.

Enhancements to `isAliasedWithSpace` method:

* [`src/Helpers/SqlUtils.php`](diffhunk://#diff-1e5d9528a5af296c1c711ea1e11b3f0b719c7660df8cb35eb1e59484f77e2807L92-R93): Modified the `isAliasedWithSpace` method to accept a reference to `$matches` and updated the regular expression to capture the identifier and alias separately.

New test case for space escaping:

* [`tests/QueryBuilderTest.php`](diffhunk://#diff-d7f20e092910bce0f91a309423646ccdbb46c9124b6fa6964e5d1c1ca75dff85R759-R766): Added a new test method `testSpaceEscaping` to verify the correct handling of identifiers and aliases with spaces.