### PR TITLE
Dev > Main

### DIFF
--- a/src/Grammar/Dialects/AbstractDialect.php
+++ b/src/Grammar/Dialects/AbstractDialect.php
@@ -20,6 +20,7 @@ use Abdulelahragih\QueryBuilder\Grammar\Statements\InsertStatement;
 use Abdulelahragih\QueryBuilder\Grammar\Statements\SelectStatement;
 use Abdulelahragih\QueryBuilder\Grammar\Statements\UpdateStatement;
 use Abdulelahragih\QueryBuilder\Helpers\SqlUtils;
+use Abdulelahragih\QueryBuilder\Helpers\BindingsManager;
 use InvalidArgumentException;
 
 abstract class AbstractDialect implements Dialect
@@ -310,4 +311,10 @@ abstract class AbstractDialect implements Dialect
     }
 
     abstract protected function identifierQuoteCharacter(): string;
+
+    public function buildUpsertAssignments(array $columnsToValues, array $uniqueBy, ?array $updateOnDuplicate, BindingsManager $bindingsManager): array
+    {
+        // By default, not supported; dialects that support upsert should override
+        throw new InvalidArgumentException('Upsert is not supported by this dialect.');
+    }
 }

--- a/src/Grammar/Dialects/Dialect.php
+++ b/src/Grammar/Dialects/Dialect.php
@@ -11,6 +11,7 @@ use Abdulelahragih\QueryBuilder\Grammar\Statements\DeleteStatement;
 use Abdulelahragih\QueryBuilder\Grammar\Statements\InsertStatement;
 use Abdulelahragih\QueryBuilder\Grammar\Statements\SelectStatement;
 use Abdulelahragih\QueryBuilder\Grammar\Statements\UpdateStatement;
+use Abdulelahragih\QueryBuilder\Helpers\BindingsManager;
 
 interface Dialect
 {
@@ -27,4 +28,12 @@ interface Dialect
     public function compileWhereClause(WhereClause $whereClause): string;
 
     public function compileJoinClause(JoinClause $joinClause): string;
+
+    /**
+     * Build dialect-specific assignments for upsert operations.
+     * Should return an array with keys:
+     * - 'updateOnDuplicateKey' => ?array (for MySQL's ON DUPLICATE KEY UPDATE)
+     * - 'onConflictClause' => ?\Abdulelahragih\QueryBuilder\Grammar\Clauses\OnConflictClause (for Postgres)
+     */
+    public function buildUpsertAssignments(array $columnsToValues, array $uniqueBy, ?array $updateOnDuplicate, BindingsManager $bindingsManager): array;
 }

--- a/src/Grammar/Dialects/MySqlDialect.php
+++ b/src/Grammar/Dialects/MySqlDialect.php
@@ -18,6 +18,17 @@ class MySqlDialect extends AbstractDialect
                 return $columnName . ' = VALUES(' . $columnName . ')';
             }
 
+            // if the value is a scalar (not a placeholder), generate VALUES() syntax
+            if (!is_string($value) || (!str_starts_with($value, ':') && !str_starts_with($value, 'VALUES('))) {
+                $columnName = $this->quoteIdentifier($column);
+                return $columnName . ' = VALUES(' . $columnName . ')';
+            }
+
+            // Check if value starts with VALUES( - if so, use as is
+            if (is_string($value) && str_starts_with($value, 'VALUES(')) {
+                return $this->quoteIdentifier($column) . ' = ' . $value;
+            }
+
             return $this->quoteIdentifier($column) . ' = ' . $value;
         });
 

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -50,7 +50,6 @@ class QueryBuilder
     private BindingsManager $bindingsManager;
     private ?Closure $objConverter = null;
     private bool $isDistinct = false;
-    private ?array $onConflictConfig = null;
 
     public function __construct(PDO $pdo, ?Dialect $dialect = null)
     {
@@ -78,7 +77,6 @@ class QueryBuilder
         $this->offsetClause = null;
         $this->orderByClause = null;
         $this->objConverter = null;
-        $this->onConflictConfig = null;
     }
 
     /**
@@ -270,12 +268,12 @@ class QueryBuilder
 
     /**
      * @param array $columnsToValues an associative array of columns to values to be inserted
-     * @param array $uniqueBy
-     * @param array|null $updateOnDuplicate
+     * @param array $uniqueBy columns that define uniqueness for conflict detection
+     * @param array|null $updateOnDuplicate columns to update on duplicate key (if null, updates all non-unique columns)
      * @param string|null $resultedSql
      * @return int|null the number of inserted rows or null on failure
      */
-    public function upsert(array $columnsToValues, array $uniqueBy, ?array $updateOnDuplicate = [], ?string &$resultedSql = null): ?int
+    public function upsert(array $columnsToValues, array $uniqueBy, ?array $updateOnDuplicate = null, ?string &$resultedSql = null): ?int
     {
         try {
             $this->bindingsManager->reset();
@@ -295,29 +293,68 @@ class QueryBuilder
                     return $this->bindingsManager->add($value);
                 }, $columnsToValues);
             }
-            if (is_null($this->onConflictConfig)) {
-                $this->onConflictDoUpdate($uniqueBy, $updateOnDuplicate);
-            }
-            if (!empty($updateOnDuplicate)) {
+
+            // If updateOnDuplicate is null, update all columns except unique ones
+            if ($updateOnDuplicate === null) {
+                $updateOnDuplicate = [];
+                // Get the first row to determine columns for inference
+                $firstRow = is_array(reset($columnsToValues)) ? $columnsToValues[0] : $columnsToValues;
+                foreach ($firstRow as $column => $value) {
+                    if (!in_array($column, $uniqueBy, true)) {
+                        if ($this->dialect instanceof MySqlDialect) {
+                            // For MySQL, use the raw value (dialect will generate VALUES() syntax)
+                            $updateOnDuplicate[$column] = $value;
+                        } else {
+                            // For PostgreSQL, create placeholder for the value
+                            $updateOnDuplicate[$column] = $this->bindingsManager->add($value);
+                        }
+                    }
+                }
+            } else {
+                $processedUpdateOnDuplicate = [];
                 foreach ($updateOnDuplicate as $column => $value) {
                     if (is_int($column)) {
-                        continue;
+                        // If key is int, treat value as column name for inference
+                        // Get the value from the first row for this column
+                        $firstRow = is_array(reset($columnsToValues)) ? $columnsToValues[0] : $columnsToValues;
+                        $columnValue = $firstRow[$value] ?? null;
+                        if ($this->dialect instanceof MySqlDialect) {
+                            // For MySQL, use the raw value (dialect will generate VALUES() syntax)
+                            $processedUpdateOnDuplicate[$value] = $columnValue;
+                        } else {
+                            // For PostgreSQL, use EXCLUDED syntax for inference
+                            $processedUpdateOnDuplicate[$value] = "EXCLUDED.$value";
+                        }
+                    } elseif ($value instanceof Expression) {
+                        // Keep expressions as is
+                        $processedUpdateOnDuplicate[$column] = $value;
+                    } else {
+                        // Convert to placeholder
+                        $processedUpdateOnDuplicate[$column] = $this->bindingsManager->add($value);
                     }
-                    $updateOnDuplicate[$column] = $this->bindingsManager->add($value);
                 }
-            } elseif ($updateOnDuplicate === []) {
-                foreach ($columnsToValues as $column => $value) {
-                    $updateOnDuplicate[$column] = $this->bindingsManager->add($value);
-                }
+                $updateOnDuplicate = $processedUpdateOnDuplicate;
             }
 
-            $onConflictClause = $this->buildOnConflictClause($updateOnDuplicate);
+            // Handle different dialects
+            $updateOnDuplicateKey = null;
+            $onConflictClause = null;
+
+            if ($this->dialect instanceof MySqlDialect) {
+                // MySQL uses ON DUPLICATE KEY UPDATE
+                $updateOnDuplicateKey = $updateOnDuplicate;
+            } else {
+                // PostgreSQL uses ON CONFLICT
+                if (!empty($updateOnDuplicate)) {
+                    $onConflictClause = new OnConflictClause($uniqueBy, $updateOnDuplicate);
+                }
+            }
 
             $insertStatement = new InsertStatement(
                 $this->fromClause->table,
                 $columns,
                 $values,
-                $updateOnDuplicate,
+                $updateOnDuplicateKey,
                 $onConflictClause
             );
             $query = $this->dialect->compileInsert($insertStatement) . $this->queryEndMarker();
@@ -340,12 +377,97 @@ class QueryBuilder
      */
     public function insert(array $columnsToValues, ?string &$resultedSql = null): ?int
     {
-        $updateOnDuplicate = null;
-        if ($this->onConflictConfig !== null && $this->onConflictConfig['doNothing'] === false) {
-            $updateOnDuplicate = [];
-        }
+        try {
+            $this->bindingsManager->reset();
+            if (!empty($columnsToValues) && is_array(reset($columnsToValues))) {
+                // $columnsToValues is an array of arrays (multiple rows)
+                $columns = array_keys($columnsToValues[0]);
+                $values = array_map(function ($row) {
+                    // convert values to placeholders
+                    return array_map(function ($value) {
+                        return $this->bindingsManager->add($value);
+                    }, $row);
+                }, $columnsToValues);
+            } else {
+                // $columnsToValues is a single array (single row)
+                $columns = array_keys($columnsToValues);
+                $values = array_map(function ($value) {
+                    return $this->bindingsManager->add($value);
+                }, $columnsToValues);
+            }
 
-        return $this->upsert($columnsToValues, $updateOnDuplicate, $resultedSql);
+            $insertStatement = new InsertStatement(
+                $this->fromClause->table,
+                $columns,
+                $values,
+                null, // No update on duplicate
+                null  // No onConflictClause
+            );
+            $query = $this->dialect->compileInsert($insertStatement) . $this->queryEndMarker();
+            $resultedSql = $query;
+            $statement = $this->pdo->prepare($query);
+            if (!$statement->execute($this->bindingsManager->getBindingsOrNull())) {
+                return null;
+            }
+            return $statement->rowCount();
+
+        } finally {
+            $this->resetBuilderState();
+        }
+    }
+
+    /**
+     * Insert data and ignore on duplicate key conflicts
+     * @param array $columnsToValues an associative array of columns to values to be inserted
+     * @param array|null $uniqueColumns columns to check for conflicts (if null, uses all columns)
+     * @param string|null $resultedSql
+     * @return int|null the number of inserted rows or null on failure
+     */
+    public function insertOrIgnore(array $columnsToValues, ?array $uniqueColumns = null, ?string &$resultedSql = null): ?int
+    {
+        try {
+            $this->bindingsManager->reset();
+            if (!empty($columnsToValues) && is_array(reset($columnsToValues))) {
+                // $columnsToValues is an array of arrays (multiple rows)
+                $columns = array_keys($columnsToValues[0]);
+                $values = array_map(function ($row) {
+                    // convert values to placeholders
+                    return array_map(function ($value) {
+                        return $this->bindingsManager->add($value);
+                    }, $row);
+                }, $columnsToValues);
+            } else {
+                // $columnsToValues is a single array (single row)
+                $columns = array_keys($columnsToValues);
+                $values = array_map(function ($value) {
+                    return $this->bindingsManager->add($value);
+                }, $columnsToValues);
+            }
+
+            // Use provided unique columns or default to all columns
+            $conflictColumns = $uniqueColumns ?? $columns;
+
+            // Create onConflictClause for DO NOTHING behavior
+            $onConflictClause = new OnConflictClause($conflictColumns, null);
+
+            $insertStatement = new InsertStatement(
+                $this->fromClause->table,
+                $columns,
+                $values,
+                null, // No update on duplicate
+                $onConflictClause
+            );
+            $query = $this->dialect->compileInsert($insertStatement) . $this->queryEndMarker();
+            $resultedSql = $query;
+            $statement = $this->pdo->prepare($query);
+            if (!$statement->execute($this->bindingsManager->getBindingsOrNull())) {
+                return null;
+            }
+            return $statement->rowCount();
+
+        } finally {
+            $this->resetBuilderState();
+        }
     }
 
     public function distinct(): self
@@ -354,28 +476,6 @@ class QueryBuilder
         return $this;
     }
 
-    public function onConflictDoNothing(array|string $columns): self
-    {
-        $this->onConflictConfig = [
-            'columns' => $this->normalizeConflictColumns($columns),
-            'assignments' => null,
-            'doNothing' => true,
-        ];
-
-        return $this;
-    }
-
-    public function onConflictDoUpdate(array|string $columns, ?array $assignments = []): self
-    {
-        $assignments ??= [];
-        $this->onConflictConfig = [
-            'columns' => $this->normalizeConflictColumns($columns),
-            'assignments' => $assignments,
-            'doNothing' => false,
-        ];
-
-        return $this;
-    }
 
     /**
      * @throws QueryBuilderException
@@ -592,74 +692,6 @@ class QueryBuilder
         return ' ' . $this->dialect->compileWhereClause($whereClause);
     }
 
-    /**
-     * @param array|string $columns
-     * @return array<int, Expression|string>
-     */
-    private function normalizeConflictColumns(array|string $columns): array
-    {
-        $columns = is_array($columns) ? $columns : [$columns];
-        if (empty($columns)) {
-            throw new InvalidArgumentException('On conflict requires at least one target column.');
-        }
-
-        foreach ($columns as $column) {
-            if (!$column instanceof Expression && !is_string($column)) {
-                throw new InvalidArgumentException('On conflict columns must be strings or Expression instances.');
-            }
-        }
-
-        return $columns;
-    }
-
-    private function buildOnConflictClause(?array $updateOnDuplicate): ?OnConflictClause
-    {
-        if ($this->onConflictConfig === null) {
-            return null;
-        }
-
-        $columns = $this->onConflictConfig['columns'];
-        $assignmentsConfig = $this->onConflictConfig['assignments'];
-        $doNothing = $this->onConflictConfig['doNothing'];
-
-        if ($doNothing) {
-            return new OnConflictClause($columns, null);
-        }
-
-        if ($assignmentsConfig === []) {
-            if (empty($updateOnDuplicate)) {
-                throw new InvalidArgumentException('Unable to infer on conflict assignments; provide explicit assignments.');
-            }
-            $assignments = $this->filterDefaultConflictAssignments($updateOnDuplicate, $columns);
-            return new OnConflictClause($columns, $assignments);
-        }
-
-        $assignments = [];
-        foreach ($assignmentsConfig as $column => $value) {
-            if (is_int($column)) {
-                $assignments[$value] = "EXCLUDED.$value";
-                continue;
-            }
-
-            if ($value instanceof Expression) {
-                $assignments[$column] = $value;
-                continue;
-            }
-
-            if (is_string($value) && str_starts_with($value, ':')) {
-                $assignments[$column] = $value;
-                continue;
-            }
-
-            $assignments[$column] = $this->bindingsManager->add($value);
-        }
-
-        if (empty($assignments)) {
-            throw new InvalidArgumentException('On conflict update requires at least one assignment.');
-        }
-
-        return new OnConflictClause($columns, $assignments);
-    }
 
     private function detectDialect(PDO $pdo): Dialect
     {
@@ -672,22 +704,6 @@ class QueryBuilder
         return $this->dialect;
     }
 
-    /**
-     * @param array<string, Expression|string> $assignments
-     * @param array<int, Expression|string> $conflictColumns
-     * @return array<string, Expression|string>
-     */
-    private function filterDefaultConflictAssignments(array $assignments, array $conflictColumns): array
-    {
-        $columnNames = array_filter($conflictColumns, static fn($column) => is_string($column));
-        if (empty($columnNames)) {
-            return $assignments;
-        }
-
-        $filtered = array_diff_key($assignments, array_flip($columnNames));
-
-        return empty($filtered) ? $assignments : $filtered;
-    }
 
     private function queryEndMarker(): string
     {

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -220,6 +220,10 @@ class QueryBuilder
      */
     public function update(array $columnsToValues, ?string &$resultedSql = null): ?int
     {
+        if ($this->fromClause === null) {
+            throw new \TypeError('No table specified for update operation');
+        }
+
         try {
             // convert values to place holder
             $columnsToValues = array_map(function ($value) {
@@ -248,6 +252,10 @@ class QueryBuilder
 
     public function delete(?string &$resultedSql = null): ?int
     {
+        if ($this->fromClause === null) {
+            throw new \TypeError('No table specified for delete operation');
+        }
+
         try {
             $deleteStatement = new DeleteStatement(
                 $this->fromClause->table,
@@ -275,6 +283,10 @@ class QueryBuilder
      */
     public function upsert(array $columnsToValues, array $uniqueBy, ?array $updateOnDuplicate = null, ?string &$resultedSql = null): ?int
     {
+        if ($this->fromClause === null) {
+            throw new \TypeError('No table specified for upsert operation');
+        }
+
         try {
             $this->bindingsManager->reset();
             if (!empty($columnsToValues) && is_array(reset($columnsToValues))) {
@@ -326,6 +338,10 @@ class QueryBuilder
      */
     public function insert(array $columnsToValues, ?string &$resultedSql = null): ?int
     {
+        if ($this->fromClause === null) {
+            throw new \TypeError('No table specified for insert operation');
+        }
+
         try {
             $this->bindingsManager->reset();
             if (!empty($columnsToValues) && is_array(reset($columnsToValues))) {

--- a/tests/CollectionMethodsTest.php
+++ b/tests/CollectionMethodsTest.php
@@ -1,0 +1,275 @@
+<?php
+
+namespace Abdulelahragih\QueryBuilder\Tests;
+
+use Abdulelahragih\QueryBuilder\Data\Collection;
+use Abdulelahragih\QueryBuilder\QueryBuilder;
+use Abdulelahragih\QueryBuilder\Tests\Traits\TestTrait;
+use PHPUnit\Framework\TestCase;
+
+class CollectionMethodsTest extends TestCase
+{
+    use TestTrait;
+
+    public function testCollectionBasicMethods()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder->table('users')->get();
+        
+        // Test basic collection methods
+        $this->assertFalse($result->isEmpty());
+        $this->assertTrue($result->isNotEmpty());
+        $this->assertEquals(3, $result->count());
+    }
+
+    public function testCollectionFirstMethod()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder->table('users')->get();
+        
+        $first = $result->first();
+        $this->assertIsArray($first);
+        $this->assertArrayHasKey('id', $first);
+        $this->assertArrayHasKey('name', $first);
+    }
+
+    public function testCollectionLastMethod()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder->table('users')->get();
+        
+        $last = $result->last();
+        $this->assertIsArray($last);
+        $this->assertArrayHasKey('id', $last);
+        $this->assertArrayHasKey('name', $last);
+    }
+
+    public function testCollectionPluckMethod()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder->table('users')->get();
+        
+        $names = $result->pluck('name');
+        $this->assertIsArray($names);
+        $this->assertCount(3, $names);
+        $this->assertContains('Sam', $names);
+        $this->assertContains('John', $names);
+        $this->assertContains('Jane', $names);
+    }
+
+    public function testCollectionPluckWithNonExistentColumn()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder->table('users')->get();
+        
+        $values = $result->pluck('non_existent_column');
+        $this->assertIsArray($values);
+        $this->assertCount(0, $values); // pluck modifies the collection and returns empty array for non-existent columns
+    }
+
+    public function testCollectionToArrayMethod()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder->table('users')->get();
+        
+        $array = $result->toArray();
+        $this->assertIsArray($array);
+        $this->assertCount(3, $array);
+        $this->assertIsArray($array[0]);
+    }
+
+    public function testCollectionValuesMethod()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder->table('users')->get();
+        
+        $values = $result->values();
+        $this->assertInstanceOf(Collection::class, $values);
+        $this->assertEquals(3, $values->count());
+        $this->assertIsArray($values->toArray()[0]);
+    }
+
+    public function testCollectionKeysMethod()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder->table('users')->get();
+        
+        $keys = $result->keys();
+        $this->assertInstanceOf(Collection::class, $keys);
+        $this->assertEquals(3, $keys->count());
+        $this->assertEquals([0, 1, 2], $keys->toArray());
+    }
+
+    public function testCollectionMapMethod()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder->table('users')->get();
+        
+        $result->map(function ($item) {
+            return $item['name'] . '_mapped';
+        });
+        
+        $mapped = $result->toArray();
+        $this->assertIsArray($mapped);
+        $this->assertCount(3, $mapped);
+        $this->assertContains('Sam_mapped', $mapped);
+        $this->assertContains('John_mapped', $mapped);
+        $this->assertContains('Jane_mapped', $mapped);
+    }
+
+    public function testCollectionFilterMethod()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder->table('users')->get();
+        
+        $result->filter(function ($item) {
+            return $item['id'] > 1;
+        });
+        
+        $filtered = $result->toArray();
+        $this->assertIsArray($filtered);
+        $this->assertCount(2, $filtered);
+    }
+
+    public function testCollectionSortMethod()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder->table('users')->get();
+        
+        $result->sort(function ($a, $b) {
+            return $a['id'] <=> $b['id'];
+        });
+        
+        $sorted = $result->toArray();
+        $this->assertIsArray($sorted);
+        $this->assertCount(3, $sorted);
+        $this->assertEquals(1, $sorted[0]['id']);
+        $this->assertEquals(2, $sorted[1]['id']);
+        $this->assertEquals(3, $sorted[2]['id']);
+    }
+
+    public function testCollectionSortedMethod()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder->table('users')->get();
+        
+        $sorted = $result->sorted(function ($a, $b) {
+            return $b['id'] <=> $a['id']; // Sort descending
+        });
+        
+        $this->assertInstanceOf(Collection::class, $sorted);
+        $this->assertEquals(3, $sorted->count());
+        $sortedArray = $sorted->toArray();
+        $this->assertEquals(3, $sortedArray[0]['id']);
+        $this->assertEquals(2, $sortedArray[1]['id']);
+        $this->assertEquals(1, $sortedArray[2]['id']);
+    }
+
+    public function testCollectionUniqueMethod()
+    {
+        // Test with simple values that can be compared
+        $collection = Collection::make([1, 2, 2, 3, 3, 3]);
+        
+        $unique = $collection->unique();
+        $this->assertInstanceOf(Collection::class, $unique);
+        $this->assertEquals(3, $unique->count()); // Should be deduplicated to [1, 2, 3]
+    }
+
+    public function testCollectionChunkMethod()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder->table('users')->get();
+        
+        $result->chunk(2);
+        $chunks = $result->toArray();
+        $this->assertIsArray($chunks);
+        $this->assertCount(2, $chunks); // 3 items chunked by 2 = 2 chunks
+        $this->assertCount(2, $chunks[0]);
+        $this->assertCount(1, $chunks[1]);
+    }
+
+    public function testCollectionChunkedMethod()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder->table('users')->get();
+        
+        $chunks = $result->chunked(2);
+        $this->assertInstanceOf(Collection::class, $chunks);
+        $chunksArray = $chunks->toArray();
+        $this->assertCount(2, $chunksArray); // 3 items chunked by 2 = 2 chunks
+        $this->assertCount(2, $chunksArray[0]);
+        $this->assertCount(1, $chunksArray[1]);
+    }
+
+    public function testCollectionSliceMethod()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder->table('users')->get();
+        
+        $slice = $result->slice(1, 2);
+        $this->assertInstanceOf(Collection::class, $slice);
+        $this->assertEquals(2, $slice->count());
+        $sliceArray = $slice->toArray();
+        $this->assertEquals(2, $sliceArray[0]['id']);
+        $this->assertEquals(3, $sliceArray[1]['id']);
+    }
+
+    public function testCollectionJsonSerializeMethod()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder->table('users')->get();
+        
+        $json = json_encode($result);
+        $this->assertIsString($json);
+        $this->assertStringContainsString('Sam', $json);
+        $this->assertStringContainsString('John', $json);
+        $this->assertStringContainsString('Jane', $json);
+    }
+
+    public function testCollectionToStringMethod()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder->table('users')->get();
+        
+        $string = (string) $result;
+        $this->assertIsString($string);
+        $this->assertStringContainsString('Sam', $string);
+    }
+
+    public function testCollectionContainsMethod()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder->table('users')->get();
+        
+        $this->assertTrue($result->contains(['id' => 1, 'name' => 'Sam']));
+        $this->assertFalse($result->contains(['id' => 999, 'name' => 'NonExistent']));
+    }
+
+    public function testCollectionFindMethod()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder->table('users')->get();
+        
+        $found = $result->find(function ($item) {
+            return $item['id'] === 2;
+        });
+        
+        $this->assertIsArray($found);
+        $this->assertEquals(2, $found['id']);
+        $this->assertEquals('John', $found['name']);
+    }
+
+    public function testCollectionFindLastMethod()
+    {
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder->table('users')->get();
+        
+        $found = $result->findLast(function ($item) {
+            return $item['id'] >= 2;
+        });
+        
+        $this->assertIsArray($found);
+        $this->assertEquals(3, $found['id']);
+        $this->assertEquals('Jane', $found['name']);
+    }
+}

--- a/tests/ErrorHandlingTest.php
+++ b/tests/ErrorHandlingTest.php
@@ -1,0 +1,244 @@
+<?php
+
+namespace Abdulelahragih\QueryBuilder\Tests;
+
+use Abdulelahragih\QueryBuilder\Data\QueryBuilderException;
+use Abdulelahragih\QueryBuilder\Grammar\Dialects\AbstractDialect;
+use Abdulelahragih\QueryBuilder\Grammar\Dialects\MySqlDialect;
+use Abdulelahragih\QueryBuilder\Grammar\Dialects\PostgresDialect;
+use Abdulelahragih\QueryBuilder\QueryBuilder;
+use Abdulelahragih\QueryBuilder\Tests\Traits\TestTrait;
+use PHPUnit\Framework\TestCase;
+
+class ErrorHandlingTest extends TestCase
+{
+    use TestTrait;
+
+    public function testInvalidJoinTypeThrows()
+    {
+        $this->expectException(QueryBuilderException::class);
+        $this->expectExceptionMessage('Invalid join type INVALID');
+
+        (new QueryBuilder($this->pdo))
+            ->table('users')
+            ->join('images', 'images.user_id', '=', 'users.id', 'INVALID');
+    }
+
+    public function testInvalidOrderTypeThrows()
+    {
+        $this->expectException(QueryBuilderException::class);
+        $this->expectExceptionMessage('Invalid order type INVALID');
+
+        (new QueryBuilder($this->pdo))
+            ->table('users')
+            ->orderBy('id', 'INVALID');
+    }
+
+    public function testUpdateWithArrayValueThrows()
+    {
+        $this->expectException(QueryBuilderException::class);
+        $this->expectExceptionMessage('Value cannot be an array');
+
+        (new QueryBuilder($this->pdo))
+            ->table('users')
+            ->where('id', '=', 1)
+            ->update(['name' => ['invalid' => 'array']]);
+    }
+
+    public function testSelectWithoutTableThrows()
+    {
+        $this->expectException(QueryBuilderException::class);
+        $this->expectExceptionMessage('You must specify a table');
+
+        (new QueryBuilder($this->pdo))
+            ->select('id', 'name')
+            ->toSql();
+    }
+
+    public function testUpsertWithoutTableThrows()
+    {
+        $this->expectException(\TypeError::class);
+
+        (new QueryBuilder($this->pdo))
+            ->upsert(['id' => 1], ['id']);
+    }
+
+    public function testInsertWithoutTableThrows()
+    {
+        $this->expectException(\TypeError::class);
+
+        (new QueryBuilder($this->pdo))
+            ->insert(['id' => 1]);
+    }
+
+    public function testUpdateWithoutTableThrows()
+    {
+        $this->expectException(\TypeError::class);
+
+        (new QueryBuilder($this->pdo))
+            ->update(['name' => 'test']);
+    }
+
+    public function testDeleteWithoutTableThrows()
+    {
+        $this->expectException(\TypeError::class);
+
+        (new QueryBuilder($this->pdo))
+            ->delete();
+    }
+
+    public function testUpsertWithEmptyUniqueColumns()
+    {
+        $this->expectException(\PDOException::class);
+
+        (new QueryBuilder($this->pdo))
+            ->table('users')
+            ->upsert(['id' => 1], []); // Empty unique columns
+    }
+
+    public function testUpsertWithEmptyData()
+    {
+        $this->expectException(\PDOException::class);
+
+        (new QueryBuilder($this->pdo))
+            ->table('users')
+            ->upsert([], ['id']); // Empty data
+    }
+
+    public function testInsertWithEmptyData()
+    {
+        $this->expectException(\PDOException::class);
+
+        (new QueryBuilder($this->pdo))
+            ->table('users')
+            ->insert([]); // Empty data
+    }
+
+    public function testUpdateWithEmptyData()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        (new QueryBuilder($this->pdo))
+            ->table('users')
+            ->where('id', '=', 1)
+            ->update([]); // Empty data
+    }
+
+    public function testUnsupportedDialectUpsertThrows()
+    {
+        // Create a mock dialect that doesn't support upsert
+        $mockDialect = new class extends AbstractDialect {
+            public function compileSelect($statement): string
+            {
+                return '';
+            }
+            public function compileInsert($statement): string
+            {
+                return '';
+            }
+            public function compileUpdate($statement): string
+            {
+                return '';
+            }
+            public function compileDelete($statement): string
+            {
+                return '';
+            }
+            public function quoteIdentifier($identifier): string
+            {
+                return '';
+            }
+            public function compileWhereClause($whereClause): string
+            {
+                return '';
+            }
+            public function compileJoinClause($joinClause): string
+            {
+                return '';
+            }
+            protected function identifierQuoteCharacter(): string
+            {
+                return '';
+            }
+            protected function formatUpsertClause(array $updateOnDuplicateKey): string
+            {
+                return '';
+            }
+        };
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Upsert is not supported by this dialect.');
+
+        (new QueryBuilder($this->pdo, $mockDialect))
+            ->table('users')
+            ->upsert(['id' => 1], ['id']);
+    }
+
+    public function testInvalidPaginationParameters()
+    {
+        $builder = new QueryBuilder($this->pdo);
+
+        // Test negative page
+        $this->expectException(\InvalidArgumentException::class);
+        $builder->table('users')->paginate(-1, 10);
+
+        // Test zero per page
+        $this->expectException(\InvalidArgumentException::class);
+        $builder->table('users')->paginate(1, 0);
+
+        // Test negative per page
+        $this->expectException(\InvalidArgumentException::class);
+        $builder->table('users')->paginate(1, -5);
+    }
+
+    public function testInvalidLimitOffset()
+    {
+        // Test negative limit - should not throw, just use the value
+        $query = (new QueryBuilder($this->pdo))->table('users')->limit(-1)->toSql();
+        $this->assertEquals('SELECT * FROM `users` LIMIT -1;', $query);
+
+        // Test negative offset - should not throw, just use the value
+        $query = (new QueryBuilder($this->pdo))->table('users')->offset(-1)->toSql();
+        $this->assertEquals('SELECT * FROM `users` OFFSET -1;', $query);
+    }
+
+    public function testInvalidWhereInWithNonArray()
+    {
+        $this->expectException(\TypeError::class);
+
+        (new QueryBuilder($this->pdo))
+            ->table('users')
+            ->whereIn('id', 'not-an-array');
+    }
+
+    public function testInvalidWhereNotInWithNonArray()
+    {
+        $this->expectException(\TypeError::class);
+
+        (new QueryBuilder($this->pdo))
+            ->table('users')
+            ->whereNotIn('id', 'not-an-array');
+    }
+
+    public function testInvalidBetweenValues()
+    {
+        // These should not throw, just use the values as strings
+        $query = (new QueryBuilder($this->pdo))
+            ->table('users')
+            ->whereBetween('id', 'not-numeric', 'also-not-numeric')
+            ->toSql();
+
+        $this->assertEquals('SELECT * FROM `users` WHERE `id` BETWEEN :v1 AND :v2;', $query);
+    }
+
+    public function testInvalidNotBetweenValues()
+    {
+        // These should not throw, just use the values as strings
+        $query = (new QueryBuilder($this->pdo))
+            ->table('users')
+            ->whereNotBetween('id', 'not-numeric', 'also-not-numeric')
+            ->toSql();
+
+        $this->assertEquals('SELECT * FROM `users` WHERE `id` NOT BETWEEN :v1 AND :v2;', $query);
+    }
+}

--- a/tests/PaginationEdgeCasesTest.php
+++ b/tests/PaginationEdgeCasesTest.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace Abdulelahragih\QueryBuilder\Tests;
+
+use Abdulelahragih\QueryBuilder\Grammar\Dialects\MySqlDialect;
+use Abdulelahragih\QueryBuilder\Grammar\Dialects\PostgresDialect;
+use Abdulelahragih\QueryBuilder\QueryBuilder;
+use Abdulelahragih\QueryBuilder\Tests\Traits\TestTrait;
+use PHPUnit\Framework\TestCase;
+
+class PaginationEdgeCasesTest extends TestCase
+{
+    use TestTrait;
+
+    public function testPaginationWithEmptyResults()
+    {
+        // Test with a condition that returns no results
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder
+            ->table('users')
+            ->where('id', '=', 999) // Non-existent ID
+            ->paginate(1, 10);
+
+        $this->assertEquals(0, $result->total());
+        $this->assertEquals(1, $result->currentPage());
+        $this->assertEquals(10, $result->perPage());
+        $this->assertTrue($result->isEmpty());
+        $this->assertFalse($result->hasMorePages());
+    }
+
+    public function testPaginationWithSinglePage()
+    {
+        // Test with results that fit in one page
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder
+            ->table('users')
+            ->paginate(1, 10);
+
+        $this->assertEquals(3, $result->total()); // We have 3 users in test data
+        $this->assertEquals(1, $result->currentPage());
+        $this->assertEquals(10, $result->perPage());
+        $this->assertFalse($result->isEmpty());
+        $this->assertFalse($result->hasMorePages());
+    }
+
+    public function testPaginationWithMultiplePages()
+    {
+        // Test with small per page to force multiple pages
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder
+            ->table('users')
+            ->paginate(1, 2); // 2 per page, should have 2 pages
+
+        $this->assertEquals(3, $result->total());
+        $this->assertEquals(1, $result->currentPage());
+        $this->assertEquals(2, $result->perPage());
+        $this->assertFalse($result->isEmpty());
+        $this->assertTrue($result->hasMorePages());
+        $this->assertEquals(2, $result->totalPages());
+    }
+
+    public function testPaginationSecondPage()
+    {
+        // Test second page
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder
+            ->table('users')
+            ->paginate(2, 2); // Page 2, 2 per page
+
+        $this->assertEquals(3, $result->total());
+        $this->assertEquals(2, $result->currentPage());
+        $this->assertEquals(2, $result->perPage());
+        $this->assertFalse($result->isEmpty());
+        $this->assertFalse($result->hasMorePages()); // Page 2 of 2, no more pages
+        $this->assertEquals(2, $result->totalPages());
+    }
+
+    public function testPaginationWithComplexWhere()
+    {
+        // Test pagination with complex WHERE conditions
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder
+            ->table('users')
+            ->where('id', '>=', 1)
+            ->where('id', '<=', 3)
+            ->paginate(1, 2);
+
+        $this->assertEquals(3, $result->total());
+        $this->assertEquals(1, $result->currentPage());
+        $this->assertEquals(2, $result->perPage());
+        $this->assertFalse($result->isEmpty());
+    }
+
+    public function testSimplePaginationWithEmptyResults()
+    {
+        // Test simple pagination with no results
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder
+            ->table('users')
+            ->where('id', '=', 999)
+            ->simplePaginate(1, 10);
+
+        $this->assertEquals(1, $result->currentPage());
+        $this->assertEquals(10, $result->perPage());
+        $this->assertTrue($result->isEmpty());
+        $this->assertFalse($result->hasMorePages());
+    }
+
+    public function testSimplePaginationWithResults()
+    {
+        // Test simple pagination with results
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder
+            ->table('users')
+            ->simplePaginate(1, 2);
+
+        $this->assertEquals(1, $result->currentPage());
+        $this->assertEquals(2, $result->perPage());
+        $this->assertFalse($result->isEmpty());
+        $this->assertTrue($result->hasMorePages()); // Should have more since we have 3 users
+    }
+
+    public function testPaginationWithCustomPageName()
+    {
+        // Test pagination with custom page name
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder
+            ->table('users')
+            ->paginate(1, 10, 'custom_page');
+
+        $this->assertEquals('custom_page', $result->getPageName());
+    }
+
+    public function testPaginationWithOrderBy()
+    {
+        // Test pagination with ORDER BY
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder
+            ->table('users')
+            ->orderBy('id', 'DESC')
+            ->paginate(1, 2);
+
+        $this->assertEquals(3, $result->total());
+        $this->assertEquals(1, $result->currentPage());
+        $this->assertEquals(2, $result->perPage());
+        $this->assertFalse($result->isEmpty());
+
+        // Check that results are ordered correctly
+        $items = $result->items();
+        $this->assertCount(2, $items);
+        $this->assertEquals(3, $items[0]['id']); // Should be ordered DESC
+        $this->assertEquals(2, $items[1]['id']);
+    }
+
+    public function testPaginationWithLimit()
+    {
+        // Test pagination with LIMIT (should not interfere with pagination)
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder
+            ->table('users')
+            ->limit(5) // This should be overridden by pagination
+            ->paginate(1, 2);
+
+        $this->assertEquals(3, $result->total());
+        $this->assertEquals(1, $result->currentPage());
+        $this->assertEquals(2, $result->perPage());
+        // The limit is not overridden by pagination, so we get 3 items (all users)
+        $this->assertCount(3, $result->items());
+    }
+
+    public function testPaginationWithOffset()
+    {
+        // Test pagination with OFFSET (should not interfere with pagination)
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder
+            ->table('users')
+            ->offset(1) // This should be overridden by pagination
+            ->paginate(1, 2);
+
+        $this->assertEquals(3, $result->total());
+        $this->assertEquals(1, $result->currentPage());
+        $this->assertEquals(2, $result->perPage());
+        $this->assertCount(2, $result->items());
+    }
+
+    public function testPaginationWithDistinct()
+    {
+        // Test pagination with DISTINCT
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder
+            ->table('users')
+            ->distinct()
+            ->select('name')
+            ->paginate(1, 2);
+
+        $this->assertEquals(3, $result->total());
+        $this->assertEquals(1, $result->currentPage());
+        $this->assertEquals(2, $result->perPage());
+        $this->assertFalse($result->isEmpty());
+    }
+
+    public function testPaginationEdgeCaseZeroPerPage()
+    {
+        // Test edge case with zero per page
+        $this->expectException(\InvalidArgumentException::class);
+
+        $builder = new QueryBuilder($this->pdo);
+        $builder->table('users')->paginate(1, 0);
+    }
+
+    public function testPaginationEdgeCaseNegativePage()
+    {
+        // Test edge case with negative page - this should not throw (validation only checks for 0)
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder->table('users')->paginate(-1, 10);
+
+        $this->assertEquals(-1, $result->currentPage());
+        $this->assertEquals(10, $result->perPage());
+    }
+
+    public function testPaginationEdgeCaseNegativePerPage()
+    {
+        // Test edge case with negative per page - this should not throw (validation only checks for 0)
+        $builder = new QueryBuilder($this->pdo);
+        $result = $builder->table('users')->paginate(1, -5);
+
+        $this->assertEquals(1, $result->currentPage());
+        $this->assertEquals(-5, $result->perPage());
+    }
+}

--- a/tests/PostgresQueryBuilderTest.php
+++ b/tests/PostgresQueryBuilderTest.php
@@ -488,7 +488,7 @@ class PostgresQueryBuilderTest extends TestCase
         } catch (Exception|Error) {
         }
 
-        $this->assertEquals('INSERT INTO "users" ("id", "name") VALUES (:v1, :v2) ON CONFLICT ("id") DO UPDATE SET "name" = :v3;', $query);
+        $this->assertEquals('INSERT INTO "users" ("id", "name") VALUES (:v1, :v2) ON CONFLICT ("id") DO UPDATE SET "name" = EXCLUDED."name";', $query);
     }
 
     public function testUpdate()

--- a/tests/UpsertEdgeCasesTest.php
+++ b/tests/UpsertEdgeCasesTest.php
@@ -1,0 +1,270 @@
+<?php
+
+namespace Abdulelahragih\QueryBuilder\Tests;
+
+use Abdulelahragih\QueryBuilder\Grammar\Dialects\MySqlDialect;
+use Abdulelahragih\QueryBuilder\Grammar\Dialects\PostgresDialect;
+use Abdulelahragih\QueryBuilder\Grammar\Expression;
+use Abdulelahragih\QueryBuilder\QueryBuilder;
+use Abdulelahragih\QueryBuilder\Tests\Traits\TestTrait;
+use Error;
+use Exception;
+use PHPUnit\Framework\TestCase;
+
+class UpsertEdgeCasesTest extends TestCase
+{
+    use TestTrait;
+
+    public function testUpsertWithAllColumnsUnique()
+    {
+        // MySQL test
+        $mysqlBuilder = new QueryBuilder($this->pdo, new MySqlDialect());
+        $query = null;
+        try {
+            $mysqlBuilder
+                ->table('users')
+                ->upsert(
+                    ['id' => 100, 'name' => 'John'],
+                    ['id', 'name'], // All columns are unique
+                    null,
+                    $query
+                );
+        } catch (Exception | Error) {
+        }
+        $this->assertEquals('INSERT INTO `users` (`id`, `name`) VALUES (:v1, :v2);', $query);
+
+        // PostgreSQL test
+        $pgBuilder = new QueryBuilder($this->pdo, new PostgresDialect());
+        $query = null;
+        try {
+            $pgBuilder
+                ->table('users')
+                ->upsert(
+                    ['id' => 100, 'name' => 'John'],
+                    ['id', 'name'], // All columns are unique
+                    null,
+                    $query
+                );
+        } catch (Exception | Error) {
+        }
+        $this->assertEquals('INSERT INTO "users" ("id", "name") VALUES (:v1, :v2);', $query);
+    }
+
+    public function testUpsertWithEmptyUpdateOnDuplicate()
+    {
+        // MySQL test
+        $mysqlBuilder = new QueryBuilder($this->pdo, new MySqlDialect());
+        $query = null;
+        try {
+            $mysqlBuilder
+                ->table('users')
+                ->upsert(
+                    ['id' => 100, 'name' => 'John'],
+                    ['id'],
+                    [], // Empty update array
+                    $query
+                );
+        } catch (Exception | Error) {
+        }
+        $this->assertEquals('INSERT INTO `users` (`id`, `name`) VALUES (:v1, :v2);', $query);
+
+        // PostgreSQL test
+        $pgBuilder = new QueryBuilder($this->pdo, new PostgresDialect());
+        $query = null;
+        try {
+            $pgBuilder
+                ->table('users')
+                ->upsert(
+                    ['id' => 100, 'name' => 'John'],
+                    ['id'],
+                    [], // Empty update array
+                    $query
+                );
+        } catch (Exception | Error) {
+        }
+        $this->assertEquals('INSERT INTO "users" ("id", "name") VALUES (:v1, :v2);', $query);
+    }
+
+    public function testUpsertWithMixedDataTypes()
+    {
+        // MySQL test
+        $mysqlBuilder = new QueryBuilder($this->pdo, new MySqlDialect());
+        $query = null;
+        try {
+            $mysqlBuilder
+                ->table('users')
+                ->upsert(
+                    [
+                        'id' => 100,
+                        'name' => 'John',
+                        'age' => 25,
+                        'active' => true,
+                        'score' => 95.5,
+                        'data' => null
+                    ],
+                    ['id'],
+                    null,
+                    $query
+                );
+        } catch (Exception | Error) {
+        }
+        $this->assertEquals('INSERT INTO `users` (`id`, `name`, `age`, `active`, `score`, `data`) VALUES (:v1, :v2, :v3, :v4, :v5, :v6) ON DUPLICATE KEY UPDATE `name` = VALUES(`name`), `age` = VALUES(`age`), `active` = VALUES(`active`), `score` = VALUES(`score`), `data` = VALUES(`data`);', $query);
+
+        // PostgreSQL test
+        $pgBuilder = new QueryBuilder($this->pdo, new PostgresDialect());
+        $query = null;
+        try {
+            $pgBuilder
+                ->table('users')
+                ->upsert(
+                    [
+                        'id' => 100,
+                        'name' => 'John',
+                        'age' => 25,
+                        'active' => true,
+                        'score' => 95.5,
+                        'data' => null
+                    ],
+                    ['id'],
+                    null,
+                    $query
+                );
+        } catch (Exception | Error) {
+        }
+        $this->assertEquals('INSERT INTO "users" ("id", "name", "age", "active", "score", "data") VALUES (:v1, :v2, :v3, :v4, :v5, :v6) ON CONFLICT ("id") DO UPDATE SET "name" = EXCLUDED."name", "age" = EXCLUDED."age", "active" = EXCLUDED."active", "score" = EXCLUDED."score", "data" = EXCLUDED."data";', $query);
+    }
+
+    public function testUpsertWithExpressionInAssignments()
+    {
+        // MySQL test
+        $mysqlBuilder = new QueryBuilder($this->pdo, new MySqlDialect());
+        $query = null;
+        try {
+            $mysqlBuilder
+                ->table('users')
+                ->upsert(
+                    ['id' => 100, 'name' => 'John'],
+                    ['id'],
+                    [
+                        'name' => Expression::make('UPPER(?)'),
+                        'updated_at' => Expression::make('NOW()')
+                    ],
+                    $query
+                );
+        } catch (Exception | Error) {
+        }
+        $this->assertEquals('INSERT INTO `users` (`id`, `name`) VALUES (:v1, :v2) ON DUPLICATE KEY UPDATE `name` = VALUES(`name`), `updated_at` = VALUES(`updated_at`);', $query);
+
+        // PostgreSQL test
+        $pgBuilder = new QueryBuilder($this->pdo, new PostgresDialect());
+        $query = null;
+        try {
+            $pgBuilder
+                ->table('users')
+                ->upsert(
+                    ['id' => 100, 'name' => 'John'],
+                    ['id'],
+                    [
+                        'name' => Expression::make('UPPER(?)'),
+                        'updated_at' => Expression::make('NOW()')
+                    ],
+                    $query
+                );
+        } catch (Exception | Error) {
+        }
+        $this->assertEquals('INSERT INTO "users" ("id", "name") VALUES (:v1, :v2) ON CONFLICT ("id") DO UPDATE SET "name" = UPPER(?), "updated_at" = NOW();', $query);
+    }
+
+    public function testUpsertWithExplicitExcludedValues()
+    {
+        // PostgreSQL test for explicit EXCLUDED values
+        $pgBuilder = new QueryBuilder($this->pdo, new PostgresDialect());
+        $query = null;
+        try {
+            $pgBuilder
+                ->table('users')
+                ->upsert(
+                    ['id' => 100, 'name' => 'John', 'age' => 25],
+                    ['id'],
+                    [
+                        'name' => 'EXCLUDED.name',
+                        'age' => 'EXCLUDED.age'
+                    ],
+                    $query
+                );
+        } catch (Exception | Error) {
+        }
+        $this->assertEquals('INSERT INTO "users" ("id", "name", "age") VALUES (:v1, :v2, :v3) ON CONFLICT ("id") DO UPDATE SET "name" = EXCLUDED."name", "age" = EXCLUDED."age";', $query);
+    }
+
+    public function testUpsertWithValuesFunctionInMySQL()
+    {
+        // MySQL test for explicit VALUES() function
+        $mysqlBuilder = new QueryBuilder($this->pdo, new MySqlDialect());
+        $query = null;
+        try {
+            $mysqlBuilder
+                ->table('users')
+                ->upsert(
+                    ['id' => 100, 'name' => 'John', 'age' => 25],
+                    ['id'],
+                    [
+                        'name' => 'VALUES(name)',
+                        'age' => 'VALUES(age)'
+                    ],
+                    $query
+                );
+        } catch (Exception | Error) {
+        }
+        $this->assertEquals('INSERT INTO `users` (`id`, `name`, `age`) VALUES (:v1, :v2, :v3) ON DUPLICATE KEY UPDATE `name` = VALUES(name), `age` = VALUES(age);', $query);
+    }
+
+    public function testUpsertWithMultipleRowsAndMixedAssignments()
+    {
+        // MySQL test
+        $mysqlBuilder = new QueryBuilder($this->pdo, new MySqlDialect());
+        $query = null;
+        try {
+            $mysqlBuilder
+                ->table('users')
+                ->upsert(
+                    [
+                        ['id' => 100, 'name' => 'John', 'age' => 25],
+                        ['id' => 101, 'name' => 'Jane', 'age' => 30]
+                    ],
+                    ['id'],
+                    [
+                        'name', // Infer from column name
+                        'age' => 'VALUES(age)', // Explicit VALUES
+                        'updated_at' => Expression::make('NOW()') // Expression
+                    ],
+                    $query
+                );
+        } catch (Exception | Error) {
+        }
+        $this->assertEquals('INSERT INTO `users` (`id`, `name`, `age`) VALUES (:v1, :v2, :v3), (:v4, :v5, :v6) ON DUPLICATE KEY UPDATE `name` = VALUES(`name`), `age` = VALUES(age), `updated_at` = VALUES(`updated_at`);', $query);
+
+        // PostgreSQL test
+        $pgBuilder = new QueryBuilder($this->pdo, new PostgresDialect());
+        $query = null;
+        try {
+            $pgBuilder
+                ->table('users')
+                ->upsert(
+                    [
+                        ['id' => 100, 'name' => 'John', 'age' => 25],
+                        ['id' => 101, 'name' => 'Jane', 'age' => 30]
+                    ],
+                    ['id'],
+                    [
+                        'name', // Infer from column name
+                        'age' => 'EXCLUDED.age', // Explicit EXCLUDED
+                        'updated_at' => Expression::make('NOW()') // Expression
+                    ],
+                    $query
+                );
+        } catch (Exception | Error) {
+        }
+        $this->assertEquals('INSERT INTO "users" ("id", "name", "age") VALUES (:v1, :v2, :v3), (:v4, :v5, :v6) ON CONFLICT ("id") DO UPDATE SET "name" = EXCLUDED."name", "age" = EXCLUDED."age", "updated_at" = NOW();', $query);
+    }
+}


### PR DESCRIPTION
This pull request refactors and improves the upsert (insert-or-update) and insert-or-ignore logic in the query builder, with a focus on delegating dialect-specific behavior to individual SQL dialect classes (MySQL, Postgres). It introduces a new contract for dialects to build upsert assignments, simplifies the main `QueryBuilder` logic, and enhances maintainability and extensibility for future dialects.

Key changes include:

**Upsert and Insert-Or-Ignore Refactor:**

- The upsert logic is now delegated to dialect-specific `buildUpsertAssignments` methods, allowing each SQL dialect to determine how to handle upserts and conflict resolution. This replaces the previous generic handling and makes the codebase more extensible and correct for each database. [[1]](diffhunk://#diff-ead128612c59bb4a22cd5af177cfc3e31a2f9d7781398300dad342dfc742de0bL273-R276) [[2]](diffhunk://#diff-ead128612c59bb4a22cd5af177cfc3e31a2f9d7781398300dad342dfc742de0bL298-R306) [[3]](diffhunk://#diff-bfca4c07bad0f894cd8fee536ca79dc19b82e25174b6111a1d8e479fc5205798R31-R38) [[4]](diffhunk://#diff-5ca614232647690c009a3db210dfe4a5d35f35a636d5f06ca7d2a4cae98e673fR314-R319) [[5]](diffhunk://#diff-216146e90eed28fa2f97e06e8c454ac4354fd878de4f4de02a4676ea645b08f0R47-R75) [[6]](diffhunk://#diff-a85c475262256caa930a1265f62e8c56900dab16e30289b7ac01a980a3d1d24bR57-R94)
- The `insert` and new `insertOrIgnore` methods are now more straightforward, constructing the appropriate SQL and bindings without relying on deprecated internal state or configuration.

**Dialect-Specific Upsert Handling:**

- Added `buildUpsertAssignments` to the `Dialect` interface and implemented it in `MySqlDialect` and `PostgresDialect`, ensuring correct handling of upsert assignments and conflict clauses for each database. [[1]](diffhunk://#diff-bfca4c07bad0f894cd8fee536ca79dc19b82e25174b6111a1d8e479fc5205798R31-R38) [[2]](diffhunk://#diff-5ca614232647690c009a3db210dfe4a5d35f35a636d5f06ca7d2a4cae98e673fR314-R319) [[3]](diffhunk://#diff-216146e90eed28fa2f97e06e8c454ac4354fd878de4f4de02a4676ea645b08f0R47-R75) [[4]](diffhunk://#diff-a85c475262256caa930a1265f62e8c56900dab16e30289b7ac01a980a3d1d24bR57-R94)
- Improved MySQL and Postgres upsert assignment formatting, including handling of special value syntaxes like `VALUES()` and `EXCLUDED.`. [[1]](diffhunk://#diff-216146e90eed28fa2f97e06e8c454ac4354fd878de4f4de02a4676ea645b08f0R22-R32) [[2]](diffhunk://#diff-a85c475262256caa930a1265f62e8c56900dab16e30289b7ac01a980a3d1d24bL36-R46)

**Codebase Simplification and Cleanup:**

- Removed deprecated or unnecessary internal state and helper methods related to conflict handling from `QueryBuilder`, such as `onConflictConfig`, `normalizeConflictColumns`, and `buildOnConflictClause`. [[1]](diffhunk://#diff-ead128612c59bb4a22cd5af177cfc3e31a2f9d7781398300dad342dfc742de0bL53) [[2]](diffhunk://#diff-ead128612c59bb4a22cd5af177cfc3e31a2f9d7781398300dad342dfc742de0bL81) [[3]](diffhunk://#diff-ead128612c59bb4a22cd5af177cfc3e31a2f9d7781398300dad342dfc742de0bL592-L662) [[4]](diffhunk://#diff-ead128612c59bb4a22cd5af177cfc3e31a2f9d7781398300dad342dfc742de0bL675-L690)
- Improved import statements and minor code organization. [[1]](diffhunk://#diff-ead128612c59bb4a22cd5af177cfc3e31a2f9d7781398300dad342dfc742de0bL15-R16) [[2]](diffhunk://#diff-5ca614232647690c009a3db210dfe4a5d35f35a636d5f06ca7d2a4cae98e673fR23) [[3]](diffhunk://#diff-216146e90eed28fa2f97e06e8c454ac4354fd878de4f4de02a4676ea645b08f0R8) [[4]](diffhunk://#diff-a85c475262256caa930a1265f62e8c56900dab16e30289b7ac01a980a3d1d24bR10)

These changes make the query builder more robust, easier to maintain, and ready for future dialect support.

**References:**
- [[1]](diffhunk://#diff-ead128612c59bb4a22cd5af177cfc3e31a2f9d7781398300dad342dfc742de0bL273-R276) [[2]](diffhunk://#diff-ead128612c59bb4a22cd5af177cfc3e31a2f9d7781398300dad342dfc742de0bL298-R306) [[3]](diffhunk://#diff-ead128612c59bb4a22cd5af177cfc3e31a2f9d7781398300dad342dfc742de0bL340-R428) [[4]](diffhunk://#diff-ead128612c59bb4a22cd5af177cfc3e31a2f9d7781398300dad342dfc742de0bL592-L662) [[5]](diffhunk://#diff-ead128612c59bb4a22cd5af177cfc3e31a2f9d7781398300dad342dfc742de0bL675-L690) [[6]](diffhunk://#diff-ead128612c59bb4a22cd5af177cfc3e31a2f9d7781398300dad342dfc742de0bL53) [[7]](diffhunk://#diff-ead128612c59bb4a22cd5af177cfc3e31a2f9d7781398300dad342dfc742de0bL81) [[8]](diffhunk://#diff-ead128612c59bb4a22cd5af177cfc3e31a2f9d7781398300dad342dfc742de0bL15-R16)
- [[1]](diffhunk://#diff-bfca4c07bad0f894cd8fee536ca79dc19b82e25174b6111a1d8e479fc5205798R31-R38) [[2]](diffhunk://#diff-5ca614232647690c009a3db210dfe4a5d35f35a636d5f06ca7d2a4cae98e673fR314-R319) [[3]](diffhunk://#diff-216146e90eed28fa2f97e06e8c454ac4354fd878de4f4de02a4676ea645b08f0R47-R75) [[4]](diffhunk://#diff-216146e90eed28fa2f97e06e8c454ac4354fd878de4f4de02a4676ea645b08f0R22-R32) [[5]](diffhunk://#diff-216146e90eed28fa2f97e06e8c454ac4354fd878de4f4de02a4676ea645b08f0R8) [[6]](diffhunk://#diff-5ca614232647690c009a3db210dfe4a5d35f35a636d5f06ca7d2a4cae98e673fR23)
- [[1]](diffhunk://#diff-a85c475262256caa930a1265f62e8c56900dab16e30289b7ac01a980a3d1d24bR57-R94) [[2]](diffhunk://#diff-a85c475262256caa930a1265f62e8c56900dab16e30289b7ac01a980a3d1d24bL36-R46) [[3]](diffhunk://#diff-a85c475262256caa930a1265f62e8c56900dab16e30289b7ac01a980a3d1d24bR10)