### PR TITLE
feat: implement insertGetId method for PostgreSQL to retrieve generated id using RETURNING

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,27 @@ MySQL continues to support `ON DUPLICATE KEY UPDATE` through the same `upsert` A
 
 When you omit the dialect, the builder inspects `PDO::ATTR_DRIVER_NAME` and automatically selects `PostgresDialect` for `pgsql` connections, falling back to MySQL-style quoting for everything else.
 
+### Insert And Get ID (PostgreSQL)
+
+When using the `PostgresDialect`, you can insert a single row and retrieve its generated id in one round-trip via `RETURNING`:
+
+```php
+use Abdulelahragih\QueryBuilder\Grammar\Dialects\PostgresDialect;
+
+$qb = new \Abdulelahragih\QueryBuilder\QueryBuilder($pdo, new PostgresDialect());
+
+$id = $qb->table('users')->insertGetId([
+    'name' => 'John',
+]);
+
+// Optionally specify the id column name (defaults to 'id')
+$id = $qb->table('users')->insertGetId([
+    'name' => 'Jane',
+], 'user_id');
+```
+
+Note: `insertGetId` expects a single row payload. For multi-row inserts, use `insert` or `upsert`.
+
 ## Nested Where
 You can add nested conditions to the Where clause by passing a closure to the `where` method. <br>
 ```php

--- a/tests/PostgresQueryBuilderTest.php
+++ b/tests/PostgresQueryBuilderTest.php
@@ -445,6 +445,42 @@ class PostgresQueryBuilderTest extends TestCase
         $this->assertEquals('INSERT INTO "users" ("id", "name") VALUES (:v1, :v2) ON CONFLICT ("id") DO NOTHING;', $query);
     }
 
+    public function testInsertGetIdSqlDefault()
+    {
+        $builder = new QueryBuilder($this->pdo, new PostgresDialect());
+        $query = null;
+
+        try {
+            // Only provide non-id columns; expect RETURNING "id"
+            $builder
+                ->table('users')
+                ->insertGetId([
+                    'name' => 'John'
+                ], 'id', $query);
+        } catch (Exception|Error) {
+        }
+
+        $this->assertEquals('INSERT INTO "users" ("name") VALUES (:v1) RETURNING "id";', $query);
+    }
+
+    public function testInsertGetIdSqlCustomColumn()
+    {
+        $builder = new QueryBuilder($this->pdo, new PostgresDialect());
+        $query = null;
+
+        try {
+            // Custom id column name should be quoted in RETURNING
+            $builder
+                ->table('users')
+                ->insertGetId([
+                    'name' => 'Jane'
+                ], 'user_id', $query);
+        } catch (Exception|Error) {
+        }
+
+        $this->assertEquals('INSERT INTO "users" ("name") VALUES (:v1) RETURNING "user_id";', $query);
+    }
+
     public function testUpsertWithExpression()
     {
         $builder = new QueryBuilder($this->pdo, new PostgresDialect());


### PR DESCRIPTION
This pull request adds support for inserting a single row and retrieving its generated primary key in one round-trip, specifically optimized for PostgreSQL using the `RETURNING` clause. It introduces a new `insertGetId` method, updates the documentation to reflect this feature, and adds tests to ensure correct SQL generation.

**New Feature: Insert and Get ID**

- Added a new `insertGetId` method to `QueryBuilder` that inserts a single row and returns its generated primary key. For PostgreSQL, this uses the `RETURNING` clause; for other databases, it falls back to `PDO::lastInsertId()`. The method ensures only single-row inserts are allowed and provides an option to specify a custom ID column. (`src/QueryBuilder.php`)
- Updated the documentation in `README.md` to explain how to use the new `insertGetId` method, including usage examples and notes on its behavior with different database drivers. (`README.md`)

**Testing:**

- Added tests in `tests/PostgresQueryBuilderTest.php` to verify that the generated SQL for `insertGetId` is correct for both default and custom ID columns when using PostgreSQL. (`tests/PostgresQueryBuilderTest.php`)